### PR TITLE
revamp `Extension` and `ExtParam` traits

### DIFF
--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -4,14 +4,19 @@ set -e
 
 FEATURES="compiler use-serde rand"
 
-# Use toolchain if explicitly specified
-if [ -n "$TOOLCHAIN" ]
-then
-    alias cargo="cargo +$TOOLCHAIN"
-fi
-
 cargo --version
 rustc --version
+
+MSRV=false
+if cargo --version | grep "1\.41\.0"; then
+    MSRV=true
+fi
+
+if [ "$MSRV" = true ]; then
+    cargo update -p url --precise 2.2.2
+    cargo update -p form_urlencoded --precise 1.0.1
+    cargo update -p once_cell --precise 1.13.1
+fi
 
 # Format if told to
 if [ "$DO_FMT" = true ]

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -12,7 +12,7 @@ afl_fuzz = ["afl"]
 honggfuzz_fuzz = ["honggfuzz"]
 
 [dependencies]
-honggfuzz = { version = "0.5", optional = true }
+honggfuzz = { version = "0.5", optional = true, default-features = false }
 afl = { version = "0.8", optional = true }
 regex = { version = "1.4"}
 elements-miniscript = { path = "..", features = ["compiler"] }

--- a/fuzz/travis-fuzz.sh
+++ b/fuzz/travis-fuzz.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-cargo install --force honggfuzz
+cargo install --force honggfuzz --no-default-features
 for TARGET in fuzz_targets/*; do
     FILENAME=$(basename $TARGET)
 	FILE="${FILENAME%.*}"

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -29,8 +29,8 @@ use crate::miniscript::context::ScriptContext;
 use crate::policy::{semantic, Liftable};
 use crate::util::{varint_len, witness_to_scriptsig};
 use crate::{
-    elementssig_to_rawsig, BareCtx, Error, ForEach, ForEachKey, Miniscript,
-    MiniscriptKey, Satisfier, ToPublicKey, TranslatePk, Translator,
+    elementssig_to_rawsig, BareCtx, Error, ForEach, ForEachKey, Miniscript, MiniscriptKey,
+    Satisfier, ToPublicKey, TranslatePk, Translator,
 };
 
 /// Create a Bare Descriptor. That is descriptor that is
@@ -357,4 +357,3 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Pkh<P> {
         Ok(Pkh::new(t.pk(&self.pk)?))
     }
 }
-

--- a/src/descriptor/bare.rs
+++ b/src/descriptor/bare.rs
@@ -25,13 +25,12 @@ use elements::{self, script, secp256k1_zkp, Script};
 use super::checksum::{desc_checksum, verify_checksum};
 use super::ELMTS_STR;
 use crate::expression::{self, FromTree};
-use crate::extensions::ExtParam;
 use crate::miniscript::context::ScriptContext;
 use crate::policy::{semantic, Liftable};
 use crate::util::{varint_len, witness_to_scriptsig};
 use crate::{
-    elementssig_to_rawsig, BareCtx, Error, Extension, ForEach, ForEachKey, Miniscript,
-    MiniscriptKey, Satisfier, ToPublicKey, TranslateExt, TranslatePk, Translator,
+    elementssig_to_rawsig, BareCtx, Error, ForEach, ForEachKey, Miniscript,
+    MiniscriptKey, Satisfier, ToPublicKey, TranslatePk, Translator,
 };
 
 /// Create a Bare Descriptor. That is descriptor that is
@@ -190,24 +189,6 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Bare<P> {
         T: Translator<P, Q, E>,
     {
         Ok(Bare::new(self.ms.translate_pk(t)?).expect("Translation cannot fail inside Bare"))
-    }
-}
-
-impl<PExt, QExt, PArg, QArg, Pk> TranslateExt<PExt, QExt, PArg, QArg> for Bare<Pk>
-where
-    PExt: Extension,
-    QExt: Extension,
-    PArg: ExtParam,
-    QArg: ExtParam,
-    Pk: MiniscriptKey,
-{
-    type Output = Bare<Pk>;
-
-    fn translate_ext<T, E>(&self, _translator: &mut T) -> Result<Self::Output, E>
-    where
-        T: crate::ExtTranslator<PArg, QArg, E>,
-    {
-        Ok(self.clone())
     }
 }
 
@@ -377,20 +358,3 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Pkh<P> {
     }
 }
 
-impl<PExt, QExt, PArg, QArg, Pk> TranslateExt<PExt, QExt, PArg, QArg> for Pkh<Pk>
-where
-    PExt: Extension,
-    QExt: Extension,
-    PArg: ExtParam,
-    QArg: ExtParam,
-    Pk: MiniscriptKey,
-{
-    type Output = Pkh<Pk>;
-
-    fn translate_ext<T, E>(&self, _translator: &mut T) -> Result<Self::Output, E>
-    where
-        T: crate::ExtTranslator<PArg, QArg, E>,
-    {
-        Ok(self.clone())
-    }
-}

--- a/src/descriptor/blinded.rs
+++ b/src/descriptor/blinded.rs
@@ -25,7 +25,7 @@ use elements::{self, Script};
 use super::checksum::{desc_checksum, strip_checksum, verify_checksum};
 use super::{Descriptor, TranslatePk};
 use crate::expression::{self, FromTree};
-use crate::extensions::CovExtArgs;
+use crate::extensions::{CovenantExt, CovExtArgs};
 use crate::policy::{semantic, Liftable};
 use crate::{Error, MiniscriptKey, Satisfier, ToPublicKey, Translator};
 
@@ -40,12 +40,12 @@ pub struct Blinded<Pk: MiniscriptKey> {
     /// permitted at the root level.
     ///
     /// TODO: Add blinding support to descriptor extensions
-    desc: Descriptor<Pk, CovExtArgs>,
+    desc: Descriptor<Pk, CovenantExt<CovExtArgs>>,
 }
 
 impl<Pk: MiniscriptKey> Blinded<Pk> {
     /// Create a new blinded descriptor from a descriptor and blinder
-    pub fn new(blinder: Pk, desc: Descriptor<Pk, CovExtArgs>) -> Self {
+    pub fn new(blinder: Pk, desc: Descriptor<Pk, CovenantExt<CovExtArgs>>) -> Self {
         Self { blinder, desc }
     }
 
@@ -55,12 +55,12 @@ impl<Pk: MiniscriptKey> Blinded<Pk> {
     }
 
     /// get the unblinded descriptor
-    pub fn as_unblinded(&self) -> &Descriptor<Pk, CovExtArgs> {
+    pub fn as_unblinded(&self) -> &Descriptor<Pk, CovenantExt<CovExtArgs>> {
         &self.desc
     }
 
     /// get the unblinded descriptor
-    pub fn into_unblinded(self) -> Descriptor<Pk, CovExtArgs> {
+    pub fn into_unblinded(self) -> Descriptor<Pk, CovenantExt<CovExtArgs>> {
         self.desc
     }
 }
@@ -92,7 +92,7 @@ impl_from_tree!(
     fn from_tree(top: &expression::Tree<'_>) -> Result<Self, Error> {
         if top.name == "blinded" && top.args.len() == 2 {
             let blinder = expression::terminal(&top.args[0], |pk| Pk::from_str(pk))?;
-            let desc = Descriptor::<Pk, CovExtArgs>::from_tree(&top.args[1])?;
+            let desc = Descriptor::<Pk, CovenantExt<CovExtArgs>>::from_tree(&top.args[1])?;
             if top.args[1].name == "blinded" {
                 return Err(Error::BadDescriptor(
                     "Blinding only permitted at root level".to_string(),

--- a/src/descriptor/blinded.rs
+++ b/src/descriptor/blinded.rs
@@ -25,7 +25,7 @@ use elements::{self, Script};
 use super::checksum::{desc_checksum, strip_checksum, verify_checksum};
 use super::{Descriptor, TranslatePk};
 use crate::expression::{self, FromTree};
-use crate::extensions::{CovenantExt, CovExtArgs};
+use crate::extensions::{CovExtArgs, CovenantExt};
 use crate::policy::{semantic, Liftable};
 use crate::{Error, MiniscriptKey, Satisfier, ToPublicKey, Translator};
 

--- a/src/descriptor/csfs_cov/cov.rs
+++ b/src/descriptor/csfs_cov/cov.rs
@@ -51,7 +51,7 @@ use super::super::checksum::{desc_checksum, verify_checksum};
 use super::super::ELMTS_STR;
 use super::{CovError, CovOperations};
 use crate::expression::{self, FromTree};
-use crate::extensions::{ExtParam, ParseableExt};
+use crate::extensions::ParseableExt;
 use crate::miniscript::lex::{lex, Token as Tk, TokenIter};
 use crate::miniscript::limits::{
     MAX_OPS_PER_SCRIPT, MAX_SCRIPT_SIZE, MAX_STANDARD_P2WSH_SCRIPT_SIZE,
@@ -485,20 +485,18 @@ where
     }
 }
 
-impl<Pk, Ext, ExtQ, PArg, QArg> TranslateExt<Ext, ExtQ, PArg, QArg> for LegacyCSFSCov<Pk, Ext>
+impl<Pk, Ext, ExtQ> TranslateExt<Ext, ExtQ> for LegacyCSFSCov<Pk, Ext>
 where
     Pk: MiniscriptKey,
     Ext: Extension,
     ExtQ: Extension,
-    Ext: TranslateExt<Ext, ExtQ, PArg, QArg, Output = ExtQ>,
-    PArg: ExtParam,
-    QArg: ExtParam,
+    Ext: TranslateExt<Ext, ExtQ, Output = ExtQ>,
 {
     type Output = LegacyCSFSCov<Pk, ExtQ>;
 
     fn translate_ext<T, E>(&self, translator: &mut T) -> Result<Self::Output, E>
     where
-        T: ExtTranslator<PArg, QArg, E>,
+        T: ExtTranslator<Ext, ExtQ, E>,
     {
         Ok(LegacyCSFSCov {
             pk: self.pk.clone(),

--- a/src/descriptor/csfs_cov/mod.rs
+++ b/src/descriptor/csfs_cov/mod.rs
@@ -182,7 +182,7 @@ mod tests {
     }
 
     fn _satisfy_and_interpret(
-        desc: Descriptor<bitcoin::PublicKey, CovExtArgs>,
+        desc: Descriptor<bitcoin::PublicKey, CovenantExt<CovExtArgs>>,
         cov_sk: secp256k1_zkp::SecretKey,
     ) -> Result<(), Error> {
         assert_eq!(desc.desc_type(), DescriptorType::Cov);

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -37,7 +37,7 @@ use elements::{secp256k1_zkp as secp256k1, secp256k1_zkp, Script, TxIn};
 use {bitcoin, elements};
 
 use self::checksum::verify_checksum;
-use crate::extensions::{CovExtArgs, ExtParam, NoExtParam};
+use crate::extensions::{CovExtArgs, ExtParam, ParseableExt};
 use crate::miniscript::{Legacy, Miniscript, Segwitv0};
 use crate::{
     expression, miniscript, BareCtx, CovenantExt, Error, Extension, ExtTranslator, ForEach, ForEachKey,
@@ -245,42 +245,42 @@ pub enum Descriptor<Pk: MiniscriptKey, T: Extension = CovenantExt<CovExtArgs>> {
     LegacyCSFSCov(LegacyCSFSCov<Pk, T>),
 }
 
-impl<Pk: MiniscriptKey> From<Bare<Pk>> for Descriptor<Pk, CovenantExt<NoExtParam>> {
+impl<Pk: MiniscriptKey, Ext: Extension> From<Bare<Pk>> for Descriptor<Pk, Ext> {
     #[inline]
     fn from(inner: Bare<Pk>) -> Self {
         Descriptor::Bare(inner)
     }
 }
 
-impl<Pk: MiniscriptKey> From<Pkh<Pk>> for Descriptor<Pk, CovenantExt<NoExtParam>> {
+impl<Pk: MiniscriptKey, Ext: Extension> From<Pkh<Pk>> for Descriptor<Pk, Ext> {
     #[inline]
     fn from(inner: Pkh<Pk>) -> Self {
         Descriptor::Pkh(inner)
     }
 }
 
-impl<Pk: MiniscriptKey> From<Wpkh<Pk>> for Descriptor<Pk, CovenantExt<NoExtParam>> {
+impl<Pk: MiniscriptKey, Ext: Extension> From<Wpkh<Pk>> for Descriptor<Pk, Ext> {
     #[inline]
     fn from(inner: Wpkh<Pk>) -> Self {
         Descriptor::Wpkh(inner)
     }
 }
 
-impl<Pk: MiniscriptKey> From<Sh<Pk>> for Descriptor<Pk, CovenantExt<NoExtParam>> {
+impl<Pk: MiniscriptKey, Ext: Extension> From<Sh<Pk>> for Descriptor<Pk, Ext> {
     #[inline]
     fn from(inner: Sh<Pk>) -> Self {
         Descriptor::Sh(inner)
     }
 }
 
-impl<Pk: MiniscriptKey> From<Wsh<Pk>> for Descriptor<Pk, CovenantExt<NoExtParam>> {
+impl<Pk: MiniscriptKey, Ext: Extension> From<Wsh<Pk>> for Descriptor<Pk, Ext> {
     #[inline]
     fn from(inner: Wsh<Pk>) -> Self {
         Descriptor::Wsh(inner)
     }
 }
 
-impl<Pk: MiniscriptKey> From<Tr<Pk, NoExt>> for Descriptor<Pk, CovenantExt<NoExtParam>> {
+impl<Pk: MiniscriptKey, Ext: Extension> From<Tr<Pk, NoExt>> for Descriptor<Pk, Ext> {
     #[inline]
     fn from(inner: Tr<Pk, NoExt>) -> Self {
         Descriptor::Tr(inner)
@@ -313,7 +313,7 @@ impl DescriptorType {
     }
 }
 
-impl<Pk: MiniscriptKey, Arg: ExtParam> Descriptor<Pk, CovenantExt<Arg>> {
+impl<Pk: MiniscriptKey, Ext: Extension> Descriptor<Pk, Ext> {
     // Keys
 
     /// Create a new pk descriptor
@@ -419,7 +419,7 @@ impl<Pk: MiniscriptKey, Arg: ExtParam> Descriptor<Pk, CovenantExt<Arg>> {
     /// Errors when miniscript exceeds resource limits under Tap context
     pub fn new_tr_ext(
         key: Pk,
-        script: Option<tr::TapTree<Pk, CovenantExt<Arg>>>,
+        script: Option<tr::TapTree<Pk, Ext>>,
     ) -> Result<Self, Error> {
         Ok(Descriptor::TrExt(Tr::new(key, script)?))
     }
@@ -520,7 +520,7 @@ impl<Pk: MiniscriptKey, Arg: ExtParam> Descriptor<Pk, CovenantExt<Arg>> {
     }
 }
 
-impl<Pk: MiniscriptKey + ToPublicKey> Descriptor<Pk, CovenantExt<CovExtArgs>> {
+impl<Pk: MiniscriptKey + ToPublicKey, Ext: Extension + ParseableExt> Descriptor<Pk, Ext> {
     ///
     /// Obtains the blinded address for this descriptor
     ///
@@ -774,7 +774,7 @@ impl<Pk: MiniscriptKey, T: Extension> ForEachKey<Pk> for Descriptor<Pk, T> {
     }
 }
 
-impl Descriptor<DescriptorPublicKey> {
+impl<Ext: Extension + ParseableExt> Descriptor<DescriptorPublicKey, Ext> {
     /// Whether or not the descriptor has any wildcards
     pub fn is_deriveable(&self) -> bool {
         self.for_any_key(|key| key.as_key().is_deriveable())
@@ -786,7 +786,7 @@ impl Descriptor<DescriptorPublicKey> {
     ///
     /// In most cases, you would want to use [`Self::derived_descriptor`] directly to obtain
     /// a [`Descriptor<bitcoin::PublicKey>`]
-    pub fn derive(&self, index: u32) -> Descriptor<DerivedDescriptorKey> {
+    pub fn derive(&self, index: u32) -> Descriptor<DerivedDescriptorKey, Ext> {
         struct Derivator(u32);
 
         impl Translator<DescriptorPublicKey, DerivedDescriptorKey, ()> for Derivator {
@@ -834,7 +834,7 @@ impl Descriptor<DescriptorPublicKey> {
         &self,
         secp: &secp256k1_zkp::Secp256k1<C>,
         index: u32,
-    ) -> Result<Descriptor<bitcoin::PublicKey>, ConversionError> {
+    ) -> Result<Descriptor<bitcoin::PublicKey, Ext>, ConversionError> {
         struct Derivator<'a, C: secp256k1::Verification>(&'a secp256k1::Secp256k1<C>);
 
         impl<'a, C: secp256k1::Verification>
@@ -871,7 +871,7 @@ impl Descriptor<DescriptorPublicKey> {
     pub fn parse_descriptor<C: secp256k1_zkp::Signing>(
         secp: &secp256k1_zkp::Secp256k1<C>,
         s: &str,
-    ) -> Result<(Descriptor<DescriptorPublicKey>, KeyMap), Error> {
+    ) -> Result<(Descriptor<DescriptorPublicKey, Ext>, KeyMap), Error> {
         fn parse_key<C: secp256k1::Signing>(
             s: &String,
             key_map: &mut KeyMap,
@@ -919,7 +919,7 @@ impl Descriptor<DescriptorPublicKey> {
             }
         }
 
-        let descriptor = Descriptor::<String>::from_str(s)?;
+        let descriptor = Descriptor::<String, Ext>::from_str(s)?;
         let descriptor = descriptor
             .translate_pk(&mut keymap_pk)
             .map_err(|e| Error::Unexpected(e.to_string()))?;
@@ -960,7 +960,7 @@ impl Descriptor<DescriptorPublicKey> {
     }
 }
 
-impl Descriptor<DescriptorPublicKey, CovenantExt<CovExtArgs>> {
+impl<Ext: Extension + ParseableExt> Descriptor<DescriptorPublicKey, Ext> {
     /// Utility method for deriving the descriptor at each index in a range to find one matching
     /// `script_pubkey`.
     ///
@@ -973,12 +973,11 @@ impl Descriptor<DescriptorPublicKey, CovenantExt<CovExtArgs>> {
         secp: &secp256k1_zkp::Secp256k1<C>,
         script_pubkey: &Script,
         range: Range<u32>,
-    ) -> Result<Option<(u32, Descriptor<bitcoin::PublicKey, CovenantExt<CovExtArgs>>)>, ConversionError> {
+    ) -> Result<Option<(u32, Descriptor<bitcoin::PublicKey, Ext>)>, ConversionError> {
         let range = if self.is_deriveable() { range } else { 0..1 };
 
         for i in range {
             let concrete = self.derived_descriptor(secp, i)?;
-            println!("{} {} {}", i, &concrete, concrete.script_pubkey());
             if &concrete.script_pubkey() == script_pubkey {
                 return Ok(Some((i, concrete)));
             }
@@ -1416,7 +1415,7 @@ mod tests {
             asset_issuance: elements::AssetIssuance::default(),
             witness: elements::TxInWitness::default(),
         };
-        let bare = Descriptor::new_bare(ms.clone()).unwrap();
+        let bare: Descriptor<_, NoExt> = Descriptor::new_bare(ms.clone()).unwrap();
 
         bare.satisfy(&mut txin, &satisfier).expect("satisfaction");
         assert_eq!(
@@ -1428,7 +1427,7 @@ mod tests {
         );
         assert_eq!(bare.unsigned_script_sig(), elements::Script::new());
 
-        let pkh = Descriptor::new_pkh(pk);
+        let pkh: Descriptor<_, NoExt> = Descriptor::new_pkh(pk);
         pkh.satisfy(&mut txin, &satisfier).expect("satisfaction");
         assert_eq!(
             txin,
@@ -1442,7 +1441,7 @@ mod tests {
         );
         assert_eq!(pkh.unsigned_script_sig(), elements::Script::new());
 
-        let wpkh = Descriptor::new_wpkh(pk).unwrap();
+        let wpkh: Descriptor<_, NoExt> = Descriptor::new_wpkh(pk).unwrap();
         wpkh.satisfy(&mut txin, &satisfier).expect("satisfaction");
         assert_eq!(
             txin,
@@ -1450,7 +1449,7 @@ mod tests {
         );
         assert_eq!(wpkh.unsigned_script_sig(), elements::Script::new());
 
-        let shwpkh = Descriptor::new_sh_wpkh(pk).unwrap();
+        let shwpkh: Descriptor<_, NoExt> = Descriptor::new_sh_wpkh(pk).unwrap();
         shwpkh.satisfy(&mut txin, &satisfier).expect("satisfaction");
         let redeem_script = script::Builder::new()
             .push_opcode(opcodes::all::OP_PUSHBYTES_0)
@@ -1468,7 +1467,7 @@ mod tests {
         assert_eq!(shwpkh.unsigned_script_sig(), expected_ssig);
 
         let ms = ms_str!("c:pk_k({})", pk);
-        let sh = Descriptor::new_sh(ms.clone()).unwrap();
+        let sh: Descriptor<_, NoExt> = Descriptor::new_sh(ms.clone()).unwrap();
         sh.satisfy(&mut txin, &satisfier).expect("satisfaction");
         let expected_ssig = script::Builder::new()
             .push_slice(&sigser[..])
@@ -1479,7 +1478,7 @@ mod tests {
 
         let ms = ms_str!("c:pk_k({})", pk);
 
-        let wsh = Descriptor::new_wsh(ms.clone()).unwrap();
+        let wsh: Descriptor<_, NoExt> = Descriptor::new_wsh(ms.clone()).unwrap();
         wsh.satisfy(&mut txin, &satisfier).expect("satisfaction");
         assert_eq!(
             txin,
@@ -1490,7 +1489,7 @@ mod tests {
         );
         assert_eq!(wsh.unsigned_script_sig(), Script::new());
 
-        let shwsh = Descriptor::new_sh_wsh(ms.clone()).unwrap();
+        let shwsh: Descriptor<_, NoExt> = Descriptor::new_sh_wsh(ms.clone()).unwrap();
         shwsh.satisfy(&mut txin, &satisfier).expect("satisfaction");
         let expected_ssig = script::Builder::new()
             .push_slice(&ms.encode().to_v0_p2wsh()[..])
@@ -1856,7 +1855,7 @@ mod tests {
     #[test]
     fn test_parse_descriptor() {
         let secp = &secp256k1_zkp::Secp256k1::signing_only();
-        let (descriptor, key_map) = Descriptor::parse_descriptor(secp, "elwpkh(tprv8ZgxMBicQKsPcwcD4gSnMti126ZiETsuX7qwrtMypr6FBwAP65puFn4v6c3jrN9VwtMRMph6nyT63NrfUL4C3nBzPcduzVSuHD7zbX2JKVc/44'/0'/0'/0/*)").unwrap();
+        let (descriptor, key_map) = Descriptor::<_, NoExt>::parse_descriptor(secp, "elwpkh(tprv8ZgxMBicQKsPcwcD4gSnMti126ZiETsuX7qwrtMypr6FBwAP65puFn4v6c3jrN9VwtMRMph6nyT63NrfUL4C3nBzPcduzVSuHD7zbX2JKVc/44'/0'/0'/0/*)").unwrap();
         assert_eq!(descriptor.to_string(), "elwpkh([2cbe2a6d/44'/0'/0']tpubDCvNhURocXGZsLNqWcqD3syHTqPXrMSTwi8feKVwAcpi29oYKsDD3Vex7x2TDneKMVN23RbLprfxB69v94iYqdaYHsVz3kPR37NQXeqouVz/0/*)#pznhhta9");
         assert_eq!(key_map.len(), 1);
 
@@ -1864,7 +1863,7 @@ mod tests {
         macro_rules! check_invalid_checksum {
             ($secp: ident,$($desc: expr),*) => {
                 $(
-                    match Descriptor::parse_descriptor($secp, $desc) {
+                    match Descriptor::<_, NoExt>::parse_descriptor($secp, $desc) {
                         Err(Error::BadDescriptor(_)) => {},
                         Err(e) => panic!("Expected bad checksum for {}, got '{}'", $desc, e),
                         _ => panic!("Invalid checksum treated as valid: {}", $desc),
@@ -1886,8 +1885,8 @@ mod tests {
             "elsh(multi(2,[00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0))##tjq09x4t"
         );
 
-        Descriptor::parse_descriptor(&secp, "elsh(multi(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))#9s2ngs7u").expect("Valid descriptor with checksum");
-        Descriptor::parse_descriptor(&secp, "elsh(multi(2,[00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0))#uklept69").expect("Valid descriptor with checksum");
+        Descriptor::<_, NoExt>::parse_descriptor(&secp, "elsh(multi(2,[00000000/111'/222]xprvA1RpRA33e1JQ7ifknakTFpgNXPmW2YvmhqLQYMmrj4xJXXWYpDPS3xz7iAxn8L39njGVyuoseXzU6rcxFLJ8HFsTjSyQbLYnMpCqE2VbFWc,xprv9uPDJpEQgRQfDcW7BkF7eTya6RPxXeJCqCJGHuCJ4GiRVLzkTXBAJMu2qaMWPrS7AANYqdq6vcBcBUdJCVVFceUvJFjaPdGZ2y9WACViL4L/0))#9s2ngs7u").expect("Valid descriptor with checksum");
+        Descriptor::<_, NoExt>::parse_descriptor(&secp, "elsh(multi(2,[00000000/111'/222]xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL,xpub68NZiKmJWnxxS6aaHmn81bvJeTESw724CRDs6HbuccFQN9Ku14VQrADWgqbhhTHBaohPX4CjNLf9fq9MYo6oDaPPLPxSb7gwQN3ih19Zm4Y/0))#uklept69").expect("Valid descriptor with checksum");
     }
 
     #[test]
@@ -1898,7 +1897,7 @@ pk([d34db33f/44'/0'/0']xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgb
 pk(xpub6ERApfZwUNrhLCkDtcHTcxd75RbzS1ed54G1LkBUHQVHQKqhMkhgbmJbZRkrgZw4koxb5JaHWkY4ALHY2grBGRjaDMzQLcgJvLJuZZvRcEL/1),\
 pk(03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8))";
         let policy: policy::concrete::Policy<DescriptorPublicKey> = descriptor_str.parse().unwrap();
-        let descriptor = Descriptor::new_sh(policy.compile().unwrap()).unwrap();
+        let descriptor = Descriptor::<_, NoExt>::new_sh(policy.compile().unwrap()).unwrap();
         let derived_descriptor = descriptor.derive(42);
 
         let res_descriptor_str = "thresh(2,\
@@ -1908,7 +1907,7 @@ pk(03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8))";
         let res_policy: policy::concrete::Policy<DescriptorPublicKey> =
             res_descriptor_str.parse().unwrap();
         let res_descriptor =
-            Descriptor::<DescriptorPublicKey, CovenantExt<NoExtParam>>::new_sh(res_policy.compile().unwrap())
+            Descriptor::<DescriptorPublicKey, NoExt>::new_sh(res_policy.compile().unwrap())
                 .unwrap();
 
         assert_eq!(res_descriptor.to_string(), derived_descriptor.to_string());
@@ -1958,7 +1957,7 @@ pk(03f28773c2d975288bc7d1d205c3748651b075fbc6610e58cddeeddf8f19405aa8))";
     #[test]
     fn test_find_derivation_index_for_spk() {
         let secp = secp256k1_zkp::Secp256k1::verification_only();
-        let descriptor = Descriptor::from_str("eltr([73c5da0a/86'/0'/0']xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ/0/*)").unwrap();
+        let descriptor = Descriptor::<_, NoExt>::from_str("eltr([73c5da0a/86'/0'/0']xpub6BgBgsespWvERF3LHQu6CnqdvfEvtMcQjYrcRzx53QJjSxarj2afYWcLteoGVky7D3UKDP9QyrLprQ3VCECoY49yfdDEHGCtMMj92pReUsQ/0/*)").unwrap();
         let script_at_0_1 = Script::from_str(
             "5120c73ac1b7a518499b9642aed8cfa15d5401e5bd85ad760b937b69521c297722f0",
         )

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -40,8 +40,9 @@ use self::checksum::verify_checksum;
 use crate::extensions::{CovExtArgs, ExtParam, ParseableExt};
 use crate::miniscript::{Legacy, Miniscript, Segwitv0};
 use crate::{
-    expression, miniscript, BareCtx, CovenantExt, Error, Extension, ExtTranslator, ForEach, ForEachKey,
-    MiniscriptKey, NoExt, Satisfier, ToPublicKey, TranslateExt, TranslatePk, Translator,
+    expression, miniscript, BareCtx, CovenantExt, Error, ExtTranslator, Extension, ForEach,
+    ForEachKey, MiniscriptKey, NoExt, Satisfier, ToPublicKey, TranslateExt, TranslatePk,
+    Translator,
 };
 
 mod bare;
@@ -287,7 +288,9 @@ impl<Pk: MiniscriptKey, Ext: Extension> From<Tr<Pk, NoExt>> for Descriptor<Pk, E
     }
 }
 
-impl<Pk: MiniscriptKey, Arg: ExtParam> From<LegacyCSFSCov<Pk, CovenantExt<Arg>>> for Descriptor<Pk, CovenantExt<Arg>> {
+impl<Pk: MiniscriptKey, Arg: ExtParam> From<LegacyCSFSCov<Pk, CovenantExt<Arg>>>
+    for Descriptor<Pk, CovenantExt<Arg>>
+{
     #[inline]
     fn from(inner: LegacyCSFSCov<Pk, CovenantExt<Arg>>) -> Self {
         Descriptor::LegacyCSFSCov(inner)
@@ -417,10 +420,7 @@ impl<Pk: MiniscriptKey, Ext: Extension> Descriptor<Pk, Ext> {
 
     /// Create new tr descriptor
     /// Errors when miniscript exceeds resource limits under Tap context
-    pub fn new_tr_ext(
-        key: Pk,
-        script: Option<tr::TapTree<Pk, Ext>>,
-    ) -> Result<Self, Error> {
+    pub fn new_tr_ext(key: Pk, script: Option<tr::TapTree<Pk, Ext>>) -> Result<Self, Error> {
         Ok(Descriptor::TrExt(Tr::new(key, script)?))
     }
 
@@ -720,8 +720,7 @@ where
     }
 }
 
-impl<PExt, QExt, Pk> TranslateExt<PExt, QExt>
-    for Descriptor<Pk, PExt>
+impl<PExt, QExt, Pk> TranslateExt<PExt, QExt> for Descriptor<Pk, PExt>
 where
     PExt: Extension + TranslateExt<PExt, QExt, Output = QExt>,
     QExt: Extension,

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -738,24 +738,12 @@ where
         T: ExtTranslator<PArg, QArg, E>,
     {
         let desc = match *self {
-            Descriptor::Bare(ref bare) => Descriptor::Bare(
-                TranslateExt::<CovenantExt<PArg>, CovenantExt<QArg>, _, _>::translate_ext(bare, t)?,
-            ),
-            Descriptor::Pkh(ref pk) => Descriptor::Pkh(
-                TranslateExt::<CovenantExt<PArg>, CovenantExt<QArg>, _, _>::translate_ext(pk, t)?,
-            ),
-            Descriptor::Wpkh(ref pk) => Descriptor::Wpkh(
-                TranslateExt::<CovenantExt<PArg>, CovenantExt<QArg>, _, _>::translate_ext(pk, t)?,
-            ),
-            Descriptor::Sh(ref sh) => Descriptor::Sh(
-                TranslateExt::<CovenantExt<PArg>, CovenantExt<QArg>, _, _>::translate_ext(sh, t)?,
-            ),
-            Descriptor::Wsh(ref wsh) => Descriptor::Wsh(
-                TranslateExt::<CovenantExt<PArg>, CovenantExt<QArg>, _, _>::translate_ext(wsh, t)?,
-            ),
-            Descriptor::Tr(ref tr) => Descriptor::Tr(
-                TranslateExt::<NoExt, NoExt, _, _>::translate_ext(tr, t)?,
-            ),
+            Descriptor::Bare(ref bare) => Descriptor::Bare(bare.clone()),
+            Descriptor::Pkh(ref pk) => Descriptor::Pkh(pk.clone()),
+            Descriptor::Wpkh(ref pk) => Descriptor::Wpkh(pk.clone()),
+            Descriptor::Sh(ref sh) => Descriptor::Sh(sh.clone()),
+            Descriptor::Wsh(ref wsh) => Descriptor::Wsh(wsh.clone()),
+            Descriptor::Tr(ref tr) => Descriptor::Tr(tr.clone()),
             Descriptor::TrExt(ref tr) => Descriptor::TrExt(
                 TranslateExt::<CovenantExt<PArg>, CovenantExt<QArg>, _, _>::translate_ext(tr, t)?,
             ),

--- a/src/descriptor/pegin/dynafed_pegin.rs
+++ b/src/descriptor/pegin/dynafed_pegin.rs
@@ -29,7 +29,7 @@ use elements::secp256k1_zkp;
 
 use crate::descriptor::checksum::{desc_checksum, verify_checksum};
 use crate::expression::{self, FromTree};
-use crate::extensions::CovExtArgs;
+use crate::extensions::{CovenantExt, CovExtArgs};
 use crate::policy::{semantic, Liftable};
 use crate::{
     BtcDescriptor, BtcError, BtcFromTree, BtcLiftable, BtcPolicy, BtcSatisfier, BtcTree,
@@ -45,12 +45,12 @@ pub struct Pegin<Pk: MiniscriptKey> {
     /// The redeem elements descriptor
     ///
     /// TODO: Allow pegin redeem descriptor with extensions
-    pub elem_desc: Descriptor<Pk, CovExtArgs>,
+    pub elem_desc: Descriptor<Pk, CovenantExt<CovExtArgs>>,
 }
 
 impl<Pk: MiniscriptKey> Pegin<Pk> {
     /// Create a new LegacyPegin descriptor
-    pub fn new(fed_desc: BtcDescriptor<Pk>, elem_desc: Descriptor<Pk, CovExtArgs>) -> Self {
+    pub fn new(fed_desc: BtcDescriptor<Pk>, elem_desc: Descriptor<Pk, CovenantExt<CovExtArgs>>) -> Self {
         Self {
             fed_desc,
             elem_desc,
@@ -97,7 +97,7 @@ impl_from_tree!(
             // TODO: Confirm with Andrew about the descriptor type for dynafed
             // Assuming sh(wsh) for now.
             let fed_desc = BtcDescriptor::<Pk>::from_tree(&ms_expr)?;
-            let elem_desc = Descriptor::<Pk, CovExtArgs>::from_tree(&top.args[1])?;
+            let elem_desc = Descriptor::<Pk, CovenantExt<CovExtArgs>>::from_tree(&top.args[1])?;
             Ok(Pegin::new(fed_desc, elem_desc))
         } else {
             Err(Error::Unexpected(format!(
@@ -295,7 +295,7 @@ impl<Pk: MiniscriptKey> Pegin<Pk> {
     /// at redeem time by the user.
     /// Users can use the DescrpitorTrait operations on the output Descriptor
     /// to obtain the characteristics of the elements descriptor.
-    pub fn into_user_descriptor(self) -> Descriptor<Pk, CovExtArgs> {
+    pub fn into_user_descriptor(self) -> Descriptor<Pk, CovenantExt<CovExtArgs>> {
         self.elem_desc
     }
 }

--- a/src/descriptor/pegin/dynafed_pegin.rs
+++ b/src/descriptor/pegin/dynafed_pegin.rs
@@ -29,7 +29,7 @@ use elements::secp256k1_zkp;
 
 use crate::descriptor::checksum::{desc_checksum, verify_checksum};
 use crate::expression::{self, FromTree};
-use crate::extensions::{CovenantExt, CovExtArgs};
+use crate::extensions::{CovExtArgs, CovenantExt};
 use crate::policy::{semantic, Liftable};
 use crate::{
     BtcDescriptor, BtcError, BtcFromTree, BtcLiftable, BtcPolicy, BtcSatisfier, BtcTree,
@@ -50,7 +50,10 @@ pub struct Pegin<Pk: MiniscriptKey> {
 
 impl<Pk: MiniscriptKey> Pegin<Pk> {
     /// Create a new LegacyPegin descriptor
-    pub fn new(fed_desc: BtcDescriptor<Pk>, elem_desc: Descriptor<Pk, CovenantExt<CovExtArgs>>) -> Self {
+    pub fn new(
+        fed_desc: BtcDescriptor<Pk>,
+        elem_desc: Descriptor<Pk, CovenantExt<CovExtArgs>>,
+    ) -> Self {
         Self {
             fed_desc,
             elem_desc,

--- a/src/descriptor/pegin/legacy_pegin.rs
+++ b/src/descriptor/pegin/legacy_pegin.rs
@@ -34,7 +34,7 @@ use elements::secp256k1_zkp;
 
 use crate::descriptor::checksum::{desc_checksum, verify_checksum};
 use crate::expression::{self, FromTree};
-use crate::extensions::{CovenantExt, CovExtArgs};
+use crate::extensions::{CovExtArgs, CovenantExt};
 use crate::policy::{semantic, Liftable};
 use crate::util::varint_len;
 use crate::{

--- a/src/descriptor/pegin/legacy_pegin.rs
+++ b/src/descriptor/pegin/legacy_pegin.rs
@@ -34,7 +34,7 @@ use elements::secp256k1_zkp;
 
 use crate::descriptor::checksum::{desc_checksum, verify_checksum};
 use crate::expression::{self, FromTree};
-use crate::extensions::CovExtArgs;
+use crate::extensions::{CovenantExt, CovExtArgs};
 use crate::policy::{semantic, Liftable};
 use crate::util::varint_len;
 use crate::{
@@ -127,7 +127,7 @@ pub struct LegacyPegin<Pk: MiniscriptKey> {
     /// The elements descriptor required to redeem
     ///
     /// TODO: Allow extension user descriptors when claiming pegins
-    pub desc: Descriptor<Pk, CovExtArgs>,
+    pub desc: Descriptor<Pk, CovenantExt<CovExtArgs>>,
     // Representation of federation policy as a miniscript
     // Allows for easier implementation
     ms: BtcMiniscript<LegacyPeginKey, BtcSegwitv0>,
@@ -141,7 +141,7 @@ impl<Pk: MiniscriptKey> LegacyPegin<Pk> {
         emer_pks: Vec<LegacyPeginKey>,
         emer_k: usize,
         timelock: u32,
-        desc: Descriptor<Pk, CovExtArgs>,
+        desc: Descriptor<Pk, CovenantExt<CovExtArgs>>,
     ) -> Self {
         let fed_ms = BtcMiniscript::from_ast(BtcTerminal::Multi(fed_k, fed_pks.clone()))
             .expect("Multi type check can't fail");
@@ -169,7 +169,7 @@ impl<Pk: MiniscriptKey> LegacyPegin<Pk> {
     // Internal function to set the fields of Self according to
     // miniscript
     fn from_ms_and_desc(
-        desc: Descriptor<Pk, CovExtArgs>,
+        desc: Descriptor<Pk, CovenantExt<CovExtArgs>>,
         ms: BtcMiniscript<LegacyPeginKey, BtcSegwitv0>,
     ) -> Self {
         // Miniscript is a bunch of Arc's. So, cloning is not as bad.
@@ -279,7 +279,7 @@ impl<Pk: MiniscriptKey> LegacyPegin<Pk> {
 
     /// Create a new descriptor with hard coded values for the
     /// legacy federation and emergency keys
-    pub fn new_legacy_fed(user_desc: Descriptor<Pk, CovExtArgs>) -> Self {
+    pub fn new_legacy_fed(user_desc: Descriptor<Pk, CovenantExt<CovExtArgs>>) -> Self {
         // Taken from functionary codebase
         // TODO: Verify the keys are correct
         let pks = "
@@ -353,7 +353,7 @@ impl_from_tree!(
             let ms_expr = BtcTree::from_str(&ms_str)?;
             //
             let ms = BtcMiniscript::<LegacyPeginKey, BtcSegwitv0>::from_tree(&ms_expr);
-            let desc = Descriptor::<Pk, CovExtArgs>::from_tree(&top.args[1]);
+            let desc = Descriptor::<Pk, CovenantExt<CovExtArgs>>::from_tree(&top.args[1]);
             Ok(LegacyPegin::from_ms_and_desc(desc?, ms?))
         } else {
             Err(Error::Unexpected(format!(
@@ -533,7 +533,7 @@ impl<Pk: MiniscriptKey> LegacyPegin<Pk> {
     /// at redeem time by the user.
     /// Users can use the DescrpitorTrait operations on the output Descriptor
     /// to obtain the characteristics of the elements descriptor.
-    pub fn into_user_descriptor(self) -> Descriptor<Pk, CovExtArgs> {
+    pub fn into_user_descriptor(self) -> Descriptor<Pk, CovenantExt<CovExtArgs>> {
         self.desc
     }
 }

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -24,13 +24,12 @@ use elements::{self, secp256k1_zkp, Address, Script};
 use super::checksum::{desc_checksum, verify_checksum};
 use super::{SortedMultiVec, ELMTS_STR};
 use crate::expression::{self, FromTree};
-use crate::extensions::ExtParam;
 use crate::miniscript::context::{ScriptContext, ScriptContextError};
 use crate::policy::{semantic, Liftable};
 use crate::util::varint_len;
 use crate::{
-    elementssig_to_rawsig, Error, Extension, ForEach, ForEachKey, Miniscript, MiniscriptKey,
-    Satisfier, Segwitv0, ToPublicKey, TranslateExt, TranslatePk, Translator,
+    elementssig_to_rawsig, Error, ForEach, ForEachKey, Miniscript, MiniscriptKey,
+    Satisfier, Segwitv0, ToPublicKey, TranslatePk, Translator,
 };
 /// A Segwitv0 wsh descriptor
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -310,24 +309,6 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Wsh<P> {
     }
 }
 
-impl<PExt, QExt, PArg, QArg, Pk> TranslateExt<PExt, QExt, PArg, QArg> for Wsh<Pk>
-where
-    PExt: Extension,
-    QExt: Extension,
-    PArg: ExtParam,
-    QArg: ExtParam,
-    Pk: MiniscriptKey,
-{
-    type Output = Wsh<Pk>;
-
-    fn translate_ext<T, E>(&self, _translator: &mut T) -> Result<Self::Output, E>
-    where
-        T: crate::ExtTranslator<PArg, QArg, E>,
-    {
-        Ok(self.clone())
-    }
-}
-
 /// A bare Wpkh descriptor at top level
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
 pub struct Wpkh<Pk: MiniscriptKey> {
@@ -539,20 +520,3 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Wpkh<P> {
     }
 }
 
-impl<PExt, QExt, PArg, QArg, Pk> TranslateExt<PExt, QExt, PArg, QArg> for Wpkh<Pk>
-where
-    PExt: Extension,
-    QExt: Extension,
-    PArg: ExtParam,
-    QArg: ExtParam,
-    Pk: MiniscriptKey,
-{
-    type Output = Wpkh<Pk>;
-
-    fn translate_ext<T, E>(&self, _translator: &mut T) -> Result<Self::Output, E>
-    where
-        T: crate::ExtTranslator<PArg, QArg, E>,
-    {
-        Ok(self.clone())
-    }
-}

--- a/src/descriptor/segwitv0.rs
+++ b/src/descriptor/segwitv0.rs
@@ -28,8 +28,8 @@ use crate::miniscript::context::{ScriptContext, ScriptContextError};
 use crate::policy::{semantic, Liftable};
 use crate::util::varint_len;
 use crate::{
-    elementssig_to_rawsig, Error, ForEach, ForEachKey, Miniscript, MiniscriptKey,
-    Satisfier, Segwitv0, ToPublicKey, TranslatePk, Translator,
+    elementssig_to_rawsig, Error, ForEach, ForEachKey, Miniscript, MiniscriptKey, Satisfier,
+    Segwitv0, ToPublicKey, TranslatePk, Translator,
 };
 /// A Segwitv0 wsh descriptor
 #[derive(Clone, Ord, PartialOrd, Eq, PartialEq, Hash)]
@@ -519,4 +519,3 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Wpkh<P> {
         Ok(Wpkh::new(t.pk(&self.pk)?).expect("Uncompressed keys in Wpkh"))
     }
 }
-

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -29,8 +29,8 @@ use crate::miniscript::context::ScriptContext;
 use crate::policy::{semantic, Liftable};
 use crate::util::{varint_len, witness_to_scriptsig};
 use crate::{
-    push_opcode_size, Error, ForEach, ForEachKey, Legacy, Miniscript, MiniscriptKey,
-    Satisfier, Segwitv0, ToPublicKey, TranslatePk, Translator,
+    push_opcode_size, Error, ForEach, ForEachKey, Legacy, Miniscript, MiniscriptKey, Satisfier,
+    Segwitv0, ToPublicKey, TranslatePk, Translator,
 };
 
 /// A Legacy p2sh Descriptor
@@ -403,4 +403,3 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Sh<P> {
         Ok(Sh { inner })
     }
 }
-

--- a/src/descriptor/sh.rs
+++ b/src/descriptor/sh.rs
@@ -25,13 +25,12 @@ use elements::{self, script, secp256k1_zkp, Script};
 use super::checksum::{desc_checksum, verify_checksum};
 use super::{SortedMultiVec, Wpkh, Wsh, ELMTS_STR};
 use crate::expression::{self, FromTree};
-use crate::extensions::ExtParam;
 use crate::miniscript::context::ScriptContext;
 use crate::policy::{semantic, Liftable};
 use crate::util::{varint_len, witness_to_scriptsig};
 use crate::{
-    push_opcode_size, Error, Extension, ForEach, ForEachKey, Legacy, Miniscript, MiniscriptKey,
-    Satisfier, Segwitv0, ToPublicKey, TranslateExt, TranslatePk, Translator,
+    push_opcode_size, Error, ForEach, ForEachKey, Legacy, Miniscript, MiniscriptKey,
+    Satisfier, Segwitv0, ToPublicKey, TranslatePk, Translator,
 };
 
 /// A Legacy p2sh Descriptor
@@ -405,20 +404,3 @@ impl<P: MiniscriptKey, Q: MiniscriptKey> TranslatePk<P, Q> for Sh<P> {
     }
 }
 
-impl<PExt, QExt, PArg, QArg, Pk> TranslateExt<PExt, QExt, PArg, QArg> for Sh<Pk>
-where
-    PExt: Extension,
-    QExt: Extension,
-    PArg: ExtParam,
-    QArg: ExtParam,
-    Pk: MiniscriptKey,
-{
-    type Output = Sh<Pk>;
-
-    fn translate_ext<T, E>(&self, _translator: &mut T) -> Result<Self::Output, E>
-    where
-        T: crate::ExtTranslator<PArg, QArg, E>,
-    {
-        Ok(self.clone())
-    }
-}

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -146,10 +146,7 @@ impl<Pk: MiniscriptKey, Ext: Extension> TapTree<Pk, Ext> {
     }
 
     // Helper function to translate extensions
-    fn translate_ext_helper<T, QExt, Error>(
-        &self,
-        t: &mut T,
-    ) -> Result<TapTree<Pk, QExt>, Error>
+    fn translate_ext_helper<T, QExt, Error>(&self, t: &mut T) -> Result<TapTree<Pk, QExt>, Error>
     where
         T: crate::ExtTranslator<Ext, QExt, Error>,
         QExt: Extension,

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -14,7 +14,7 @@ use elements::{self, opcodes, secp256k1_zkp, Script};
 use super::checksum::{desc_checksum, verify_checksum};
 use super::ELMTS_STR;
 use crate::expression::{self, FromTree};
-use crate::extensions::{ExtParam, ParseableExt};
+use crate::extensions::ParseableExt;
 use crate::miniscript::Miniscript;
 use crate::policy::semantic::Policy;
 use crate::policy::Liftable;
@@ -146,17 +146,14 @@ impl<Pk: MiniscriptKey, Ext: Extension> TapTree<Pk, Ext> {
     }
 
     // Helper function to translate extensions
-    fn translate_ext_helper<T, QExt, PArg, QArg, Error>(
+    fn translate_ext_helper<T, QExt, Error>(
         &self,
         t: &mut T,
     ) -> Result<TapTree<Pk, QExt>, Error>
     where
-        T: crate::ExtTranslator<PArg, QArg, Error>,
+        T: crate::ExtTranslator<Ext, QExt, Error>,
         QExt: Extension,
-        Ext: Extension,
-        PArg: ExtParam,
-        QArg: ExtParam,
-        Ext: TranslateExt<Ext, QExt, PArg, QArg, Output = QExt>,
+        Ext: Extension + TranslateExt<Ext, QExt, Output = QExt>,
     {
         let frag = match self {
             TapTree::Tree(l, r) => TapTree::Tree(
@@ -653,20 +650,17 @@ where
     }
 }
 
-impl<PExt, QExt, PArg, QArg, Pk> TranslateExt<PExt, QExt, PArg, QArg> for Tr<Pk, PExt>
+impl<PExt, QExt, Pk> TranslateExt<PExt, QExt> for Tr<Pk, PExt>
 where
-    PExt: Extension,
+    PExt: Extension + TranslateExt<PExt, QExt, Output = QExt>,
     QExt: Extension,
-    PArg: ExtParam,
-    QArg: ExtParam,
     Pk: MiniscriptKey,
-    PExt: TranslateExt<PExt, QExt, PArg, QArg, Output = QExt>,
 {
     type Output = Tr<Pk, QExt>;
 
     fn translate_ext<T, E>(&self, translator: &mut T) -> Result<Self::Output, E>
     where
-        T: crate::ExtTranslator<PArg, QArg, E>,
+        T: crate::ExtTranslator<PExt, QExt, E>,
     {
         let translate_desc = Tr {
             internal_key: self.internal_key.clone(),

--- a/src/extensions/arith.rs
+++ b/src/extensions/arith.rs
@@ -16,7 +16,7 @@ use crate::miniscript::satisfy::{Satisfaction, Witness};
 use crate::miniscript::types::extra_props::{OpLimits, TimelockInfo};
 use crate::miniscript::types::{Base, Correctness, Dissat, ExtData, Input, Malleability};
 use crate::{
-    expression, interpreter, miniscript, script_num_size, Error, ExtTranslator, Extension,
+    expression, interpreter, miniscript, script_num_size, Error, Extension,
     Satisfier, ToPublicKey, TranslateExt,
 };
 
@@ -1032,23 +1032,6 @@ impl fmt::Display for EvalError {
                 "Transaction must be supplied to extension to arithmetic evaluation"
             ),
         }
-    }
-}
-
-impl<PExt, QExt, PArg, QArg> TranslateExt<PExt, QExt, PArg, QArg> for Arith
-where
-    PExt: Extension,
-    QExt: Extension,
-    PArg: ExtParam,
-    QArg: ExtParam,
-{
-    type Output = Arith;
-
-    fn translate_ext<T, E>(&self, _t: &mut T) -> Result<Self::Output, E>
-    where
-        T: ExtTranslator<PArg, QArg, E>,
-    {
-        Ok(self.clone())
     }
 }
 

--- a/src/extensions/arith.rs
+++ b/src/extensions/arith.rs
@@ -1040,7 +1040,7 @@ mod tests {
     use bitcoin::XOnlyPublicKey;
 
     use super::*;
-    use crate::test_utils::{StrExtTransalator, StrXOnlyKeyTranslator};
+    use crate::test_utils::{StrExtTranslator, StrXOnlyKeyTranslator};
     use crate::{Miniscript, Segwitv0, Tap, TranslatePk};
 
     #[test]

--- a/src/extensions/arith.rs
+++ b/src/extensions/arith.rs
@@ -16,8 +16,8 @@ use crate::miniscript::satisfy::{Satisfaction, Witness};
 use crate::miniscript::types::extra_props::{OpLimits, TimelockInfo};
 use crate::miniscript::types::{Base, Correctness, Dissat, ExtData, Input, Malleability};
 use crate::{
-    expression, interpreter, miniscript, script_num_size, Error, Extension,
-    Satisfier, ToPublicKey, TranslateExt,
+    expression, interpreter, miniscript, script_num_size, Error, Extension, Satisfier, ToPublicKey,
+    TranslateExt,
 };
 
 /// Enum representing arithmetic operations with transaction amounts.

--- a/src/extensions/csfs.rs
+++ b/src/extensions/csfs.rs
@@ -352,7 +352,7 @@ mod tests {
     use bitcoin::XOnlyPublicKey;
 
     use super::*;
-    use crate::test_utils::{StrExtTransalator, StrXOnlyKeyTranslator};
+    use crate::test_utils::{StrExtTranslator, StrXOnlyKeyTranslator};
     use crate::{Miniscript, Segwitv0, Tap, TranslatePk};
 
     #[test]
@@ -393,7 +393,7 @@ mod tests {
             )
             .unwrap(),
         );
-        let mut ext_t = StrExtTransalator::default();
+        let mut ext_t = StrExtTranslator::default();
         ext_t.ext_map.insert(
             "msg".to_string(),
             CovExtArgs::CsfsMsg(CsfsMsg::from_slice(&[0xab; 32]).unwrap()),

--- a/src/extensions/csfs.rs
+++ b/src/extensions/csfs.rs
@@ -10,6 +10,7 @@ use elements::hashes::hex;
 use elements::{self, opcodes, secp256k1_zkp};
 
 use super::{ArgFromStr, CovExtArgs, ExtParam, ParseableExt, TxEnv};
+use super::param::{ExtParamTranslator, TranslateExtParam};
 use crate::miniscript::context::ScriptContextError;
 use crate::miniscript::lex::{Token as Tk, TokenIter};
 use crate::miniscript::limits::MAX_STANDARD_P2WSH_STACK_ITEM_SIZE;
@@ -307,6 +308,26 @@ where
     fn translate_ext<T, E>(&self, t: &mut T) -> Result<Self::Output, E>
     where
         T: ExtTranslator<PArg, QArg, E>,
+        PArg: ExtParam,
+        QArg: ExtParam,
+    {
+        Ok(CheckSigFromStack {
+            pk: t.ext(&self.pk)?,
+            msg: t.ext(&self.msg)?,
+        })
+    }
+}
+
+impl<PArg, QArg> TranslateExtParam<PArg, QArg> for CheckSigFromStack<PArg>
+where
+    PArg: ExtParam,
+    QArg: ExtParam,
+{
+    type Output = CheckSigFromStack<QArg>;
+
+    fn translate_ext<T, E>(&self, t: &mut T) -> Result<Self::Output, E>
+    where
+        T: ExtParamTranslator<PArg, QArg, E>,
         PArg: ExtParam,
         QArg: ExtParam,
     {

--- a/src/extensions/csfs.rs
+++ b/src/extensions/csfs.rs
@@ -9,8 +9,8 @@ use bitcoin::XOnlyPublicKey;
 use elements::hashes::hex;
 use elements::{self, opcodes, secp256k1_zkp};
 
-use super::{ArgFromStr, CovExtArgs, ExtParam, ParseableExt, TxEnv};
 use super::param::{ExtParamTranslator, TranslateExtParam};
+use super::{ArgFromStr, CovExtArgs, ExtParam, ParseableExt, TxEnv};
 use crate::miniscript::context::ScriptContextError;
 use crate::miniscript::lex::{Token as Tk, TokenIter};
 use crate::miniscript::limits::MAX_STANDARD_P2WSH_STACK_ITEM_SIZE;
@@ -18,7 +18,8 @@ use crate::miniscript::satisfy::{Satisfaction, Witness};
 use crate::miniscript::types::extra_props::{OpLimits, TimelockInfo};
 use crate::miniscript::types::{Base, Correctness, Dissat, ExtData, Input, Malleability};
 use crate::{
-    expression, interpreter, miniscript, Error, Extension, ExtTranslator, Satisfier, ToPublicKey, TranslateExt,
+    expression, interpreter, miniscript, Error, ExtTranslator, Extension, Satisfier, ToPublicKey,
+    TranslateExt,
 };
 
 /// CheckSigFromStack struct
@@ -113,7 +114,8 @@ impl<T: ExtParam> Extension for CheckSigFromStack<T> {
     }
 }
 
-impl<PArg, QArg> TranslateExt<CheckSigFromStack<PArg>, CheckSigFromStack<QArg>> for CheckSigFromStack<PArg>
+impl<PArg, QArg> TranslateExt<CheckSigFromStack<PArg>, CheckSigFromStack<QArg>>
+    for CheckSigFromStack<PArg>
 where
     CheckSigFromStack<PArg>: Extension,
     CheckSigFromStack<QArg>: Extension,
@@ -142,8 +144,6 @@ where
         TranslateExtParam::translate_ext(csfs, self)
     }
 }
-
-
 
 /// Wrapper around CheckSigFromStack signature messages
 #[derive(Debug, Clone, Eq, Ord, PartialOrd, PartialEq, Hash)]

--- a/src/extensions/introspect_ops.rs
+++ b/src/extensions/introspect_ops.rs
@@ -1146,7 +1146,7 @@ mod tests {
     use bitcoin::XOnlyPublicKey;
 
     use super::*;
-    use crate::test_utils::{StrExtTransalator, StrXOnlyKeyTranslator};
+    use crate::test_utils::{StrExtTranslator, StrXOnlyKeyTranslator};
     use crate::{Miniscript, Segwitv0, Tap, TranslatePk};
 
     #[test]
@@ -1212,7 +1212,7 @@ mod tests {
         // test string rtt
         assert_eq!(ms.to_string(), s);
         let mut t = StrXOnlyKeyTranslator::default();
-        let mut ext_t = StrExtTransalator::default();
+        let mut ext_t = StrExtTranslator::default();
         {
             ext_t.ext_map.insert("V1Spk".to_string(),CovExtArgs::spk(elements::Script::from_str("5120c73ac1b7a518499b9642aed8cfa15d5401e5bd85ad760b937b69521c297722f0").unwrap()));
             ext_t.ext_map.insert("V0Spk".to_string(),CovExtArgs::spk(elements::Script::from_str("0020c73ac1b7a518499b9642aed8cfa15d5401e5bd85ad760b937b69521c297722f0").unwrap()));

--- a/src/extensions/introspect_ops.rs
+++ b/src/extensions/introspect_ops.rs
@@ -11,8 +11,8 @@ use elements::confidential::Asset;
 use elements::opcodes::all::*;
 use elements::{confidential, encode, script, Address, AddressParams};
 
-use super::{ArgFromStr, CovExtArgs, EvalError, ExtParam, ParseableExt, TxEnv};
 use super::param::{ExtParamTranslator, TranslateExtParam};
+use super::{ArgFromStr, CovExtArgs, EvalError, ExtParam, ParseableExt, TxEnv};
 use crate::expression::{FromTree, Tree};
 use crate::miniscript::context::ScriptContextError;
 use crate::miniscript::lex::{Token as Tk, TokenIter};
@@ -20,7 +20,7 @@ use crate::miniscript::satisfy::{Satisfaction, Witness};
 use crate::miniscript::types::extra_props::{OpLimits, TimelockInfo};
 use crate::miniscript::types::{Base, Correctness, Dissat, ExtData, Input, Malleability};
 use crate::{
-    expression, interpreter, script_num_size, Error, Extension, ExtTranslator, Satisfier,
+    expression, interpreter, script_num_size, Error, ExtTranslator, Extension, Satisfier,
     ToPublicKey, TranslateExt,
 };
 
@@ -514,8 +514,6 @@ where
         TranslateExtParam::translate_ext(cov_ops, self)
     }
 }
-
-
 
 /// Wrapper around [`elements::Script`] for representing script pubkeys
 // Required because the fmt::Display of elements::Script does not print hex

--- a/src/extensions/introspect_ops.rs
+++ b/src/extensions/introspect_ops.rs
@@ -12,6 +12,7 @@ use elements::opcodes::all::*;
 use elements::{confidential, encode, script, Address, AddressParams};
 
 use super::{ArgFromStr, CovExtArgs, EvalError, ExtParam, ParseableExt, TxEnv};
+use super::param::{ExtParamTranslator, TranslateExtParam};
 use crate::expression::{FromTree, Tree};
 use crate::miniscript::context::ScriptContextError;
 use crate::miniscript::lex::{Token as Tk, TokenIter};
@@ -1094,6 +1095,32 @@ where
     fn translate_ext<T, E>(&self, t: &mut T) -> Result<Self::Output, E>
     where
         T: ExtTranslator<PArg, QArg, E>,
+    {
+        match self {
+            CovOps::IsExpAsset(a) => Ok(CovOps::IsExpAsset(a._translate_ext(t)?)),
+            CovOps::IsExpValue(v) => Ok(CovOps::IsExpValue(v._translate_ext(t)?)),
+            CovOps::AssetEq(x, y) => {
+                Ok(CovOps::AssetEq(x._translate_ext(t)?, y._translate_ext(t)?))
+            }
+            CovOps::ValueEq(x, y) => {
+                Ok(CovOps::ValueEq(x._translate_ext(t)?, y._translate_ext(t)?))
+            }
+            CovOps::SpkEq(x, y) => Ok(CovOps::SpkEq(x._translate_ext(t)?, y._translate_ext(t)?)),
+            CovOps::CurrIndEq(i) => Ok(CovOps::CurrIndEq(*i)),
+        }
+    }
+}
+
+impl<PArg, QArg> TranslateExtParam<PArg, QArg> for CovOps<PArg>
+where
+    PArg: ExtParam,
+    QArg: ExtParam,
+{
+    type Output = CovOps<QArg>;
+
+    fn translate_ext<T, E>(&self, t: &mut T) -> Result<Self::Output, E>
+    where
+        T: ExtParamTranslator<PArg, QArg, E>,
     {
         match self {
             CovOps::IsExpAsset(a) => Ok(CovOps::IsExpAsset(a._translate_ext(t)?)),

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -4,10 +4,8 @@
 
 use std::{fmt, hash};
 
-use bitcoin::hashes::hex::ToHex;
-use elements::encode::serialize;
 use elements::script::Builder;
-use elements::{confidential, Transaction, TxOut};
+use elements::{Transaction, TxOut};
 
 use crate::expression::Tree;
 use crate::interpreter::{self, Stack};
@@ -23,35 +21,17 @@ mod arith;
 mod csfs;
 mod introspect_ops;
 mod outputs_pref;
+pub mod param;
 mod tx_ver;
 
 pub use arith::{Arith, EvalError, Expr, ExprInner};
 pub use csfs::{CheckSigFromStack, CsfsKey, CsfsMsg};
-pub use introspect_ops::{AssetExpr, CovOps, SpkExpr, ValueExpr};
+pub use introspect_ops::{AssetExpr, CovOps, Spk, SpkExpr, ValueExpr};
 
-use self::introspect_ops::Spk;
 pub use self::outputs_pref::LegacyOutputsPref;
+pub use self::param::{ArgFromStr, CovExtArgs, ExtParam, NoExtParam};
 pub use self::tx_ver::LegacyVerEq;
 
-/// Trait for parsing extension arg from String
-/// Parse an argument from `s` given context of parent and argument position
-///
-/// When parsing all allowed parameters from string, we need to restrict where
-/// the parameters can be allowed. For example, csfs() should not have a txout
-/// parameter.
-///
-/// All parameters that should be parsed from extensions need to implement this
-pub trait ArgFromStr: Sized {
-    /// Parse an argument from `s` given context of parent and argument position
-    fn arg_from_str(s: &str, parent: &str, pos: usize) -> Result<Self, Error>;
-}
-/// Abstract parameter to Miniscript Extension
-pub trait ExtParam: Clone + Eq + Ord + fmt::Debug + fmt::Display + hash::Hash + ArgFromStr {}
-
-impl<T> ExtParam for T where
-    T: Clone + Eq + Ord + fmt::Debug + fmt::Display + hash::Hash + ArgFromStr
-{
-}
 
 /// Extensions to elements-miniscript.
 /// Refer to implementations(unimplemented!) for example and tutorials
@@ -136,24 +116,6 @@ pub trait ParseableExt:
     where
         Pk: ToPublicKey,
         S: Satisfier<Pk>;
-}
-
-/// No Extensions for elements-miniscript
-/// All the implementations for the this function are unreachable
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
-pub enum NoExtParam {}
-
-impl fmt::Display for NoExtParam {
-    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match *self {}
-    }
-}
-
-impl ArgFromStr for NoExtParam {
-    fn arg_from_str(_s: &str, _parent: &str, _pos: usize) -> Result<Self, Error> {
-        // This will be removed in a followup commit
-        unreachable!("Called ArgFromStr for NoExt")
-    }
 }
 
 /// No Extensions for elements-miniscript
@@ -261,132 +223,6 @@ pub enum CovenantExt<T: ExtParam> {
     Arith(Arith),
     /// Cov opcodes
     Introspect(CovOps<T>),
-}
-
-/// All known Extension parameters/arguments
-#[derive(Debug, PartialEq, Eq, Clone, Hash)]
-pub enum CovExtArgs {
-    /// XOnlyPublicKey (in CSFS)
-    XOnlyKey(CsfsKey),
-    /// Message
-    CsfsMsg(CsfsMsg),
-    /// Asset
-    Asset(confidential::Asset),
-    /// Value
-    Value(confidential::Value),
-    /// Script
-    Script(Spk),
-}
-
-impl From<CsfsMsg> for CovExtArgs {
-    fn from(v: CsfsMsg) -> Self {
-        Self::CsfsMsg(v)
-    }
-}
-
-impl From<Spk> for CovExtArgs {
-    fn from(v: Spk) -> Self {
-        Self::Script(v)
-    }
-}
-
-impl From<confidential::Value> for CovExtArgs {
-    fn from(v: confidential::Value) -> Self {
-        Self::Value(v)
-    }
-}
-
-impl From<confidential::Asset> for CovExtArgs {
-    fn from(v: confidential::Asset) -> Self {
-        Self::Asset(v)
-    }
-}
-
-impl From<CsfsKey> for CovExtArgs {
-    fn from(v: CsfsKey) -> Self {
-        Self::XOnlyKey(v)
-    }
-}
-
-impl CovExtArgs {
-    /// Creates a new csfs key variant of [`CovExtArgs`]
-    pub fn csfs_key(key: bitcoin::XOnlyPublicKey) -> Self {
-        CovExtArgs::XOnlyKey(CsfsKey(key))
-    }
-
-    /// Creates a csfs message variant of [`CovExtArgs`]
-    pub fn csfs_msg(msg: elements::secp256k1_zkp::Message) -> Self {
-        CovExtArgs::CsfsMsg(CsfsMsg::new(msg.as_ref().to_vec()).expect("32 byte size message"))
-    }
-
-    /// Creates a new asset variant of [`CovExtArgs`]
-    pub fn asset(asset: confidential::Asset) -> Self {
-        Self::from(asset)
-    }
-
-    /// Creates a new value variant of [`CovExtArgs`]
-    pub fn value(value: confidential::Value) -> Self {
-        Self::from(value)
-    }
-
-    /// Creates a new script pubkey of [`CovExtArgs`]
-    pub fn spk(spk: elements::Script) -> Self {
-        Self::from(Spk(spk))
-    }
-}
-
-impl PartialOrd for CovExtArgs {
-    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        // HACKY implementation, need Ord/PartialOrd to make it work with other components
-        // in the library
-        self.to_string().partial_cmp(&other.to_string())
-    }
-}
-
-impl Ord for CovExtArgs {
-    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
-        // HACKY implementation, need Ord/PartialOrd to make it work with other components
-        // in the library
-        self.to_string().cmp(&other.to_string())
-    }
-}
-
-impl fmt::Display for CovExtArgs {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            CovExtArgs::XOnlyKey(x) => write!(f, "{}", x),
-            CovExtArgs::CsfsMsg(m) => write!(f, "{}", m),
-            CovExtArgs::Asset(a) => write!(f, "{}", serialize(a).to_hex()),
-            CovExtArgs::Value(v) => write!(f, "{}", serialize(v).to_hex()),
-            CovExtArgs::Script(s) => write!(f, "{}", s),
-        }
-    }
-}
-
-impl ArgFromStr for CovExtArgs {
-    fn arg_from_str(s: &str, parent: &str, pos: usize) -> Result<Self, Error> {
-        let arg = match (parent, pos) {
-            ("csfs", 0) => CovExtArgs::XOnlyKey(CsfsKey::arg_from_str(s, parent, pos)?),
-            ("csfs", 1) => CovExtArgs::CsfsMsg(CsfsMsg::arg_from_str(s, parent, pos)?),
-            ("asset_eq", 0) | ("asset_eq", 1) | ("is_exp_asset", 0) => {
-                CovExtArgs::Asset(confidential::Asset::arg_from_str(s, parent, pos)?)
-            }
-            ("value_eq", 0) | ("value_eq", 1) | ("is_exp_value", 0) => {
-                CovExtArgs::Value(confidential::Value::arg_from_str(s, parent, pos)?)
-            }
-            ("spk_eq", 0) | ("spk_eq", 1) => CovExtArgs::Script(Spk::arg_from_str(s, parent, pos)?),
-            _ => return Err(Error::Unexpected(s.to_string())),
-        };
-        Ok(arg)
-    }
-}
-
-impl ArgFromStr for String {
-    fn arg_from_str(s: &str, _parent: &str, _pos: usize) -> Result<Self, Error> {
-        // Abstract strings are parsed without context as they don't contain any concrete
-        // information
-        Ok(String::from(s))
-    }
 }
 
 // Apply the function on each arm

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -32,7 +32,6 @@ pub use self::outputs_pref::LegacyOutputsPref;
 pub use self::param::{ArgFromStr, CovExtArgs, ExtParam, NoExtParam};
 pub use self::tx_ver::LegacyVerEq;
 
-
 /// Extensions to elements-miniscript.
 /// Refer to implementations(unimplemented!) for example and tutorials
 pub trait Extension: Clone + Eq + Ord + fmt::Debug + fmt::Display + hash::Hash {

--- a/src/extensions/mod.rs
+++ b/src/extensions/mod.rs
@@ -193,18 +193,16 @@ impl fmt::Display for NoExt {
     }
 }
 
-impl<PExt, QExt, PArg, QArg> TranslateExt<PExt, QExt, PArg, QArg> for NoExt
+impl<PExt, QExt> TranslateExt<PExt, QExt> for NoExt
 where
     PExt: Extension,
     QExt: Extension,
-    PArg: ExtParam,
-    QArg: ExtParam,
 {
     type Output = NoExt;
 
     fn translate_ext<T, E>(&self, _t: &mut T) -> Result<Self::Output, E>
     where
-        T: ExtTranslator<PArg, QArg, E>,
+        T: ExtTranslator<PExt, QExt, E>,
     {
         match *self {}
     }
@@ -326,10 +324,10 @@ impl<T: ExtParam> fmt::Display for CovenantExt<T> {
     }
 }
 
-impl<PExt, QExt, PArg, QArg> TranslateExt<PExt, QExt, PArg, QArg> for CovenantExt<PArg>
+impl<PArg, QArg> TranslateExt<CovenantExt<PArg>, CovenantExt<QArg>> for CovenantExt<PArg>
 where
-    PExt: Extension,
-    QExt: Extension,
+    CovenantExt<PArg>: Extension,
+    CovenantExt<QArg>: Extension,
     PArg: ExtParam,
     QArg: ExtParam,
 {
@@ -337,31 +335,9 @@ where
 
     fn translate_ext<T, E>(&self, t: &mut T) -> Result<Self::Output, E>
     where
-        T: ExtTranslator<PArg, QArg, E>,
+        T: ExtTranslator<CovenantExt<PArg>, CovenantExt<QArg>, E>,
     {
-        let ext =
-            match self {
-                CovenantExt::LegacyVerEq(v) => {
-                    CovenantExt::LegacyVerEq(TranslateExt::<PExt, QExt, PArg, QArg>::translate_ext(
-                        v, t,
-                    )?)
-                }
-                CovenantExt::LegacyOutputsPref(p) => CovenantExt::LegacyOutputsPref(
-                    TranslateExt::<PExt, QExt, PArg, QArg>::translate_ext(p, t)?,
-                ),
-                CovenantExt::Csfs(c) => {
-                    CovenantExt::Csfs(TranslateExt::<PExt, QExt, PArg, QArg>::translate_ext(c, t)?)
-                }
-                CovenantExt::Arith(e) => {
-                    CovenantExt::Arith(TranslateExt::<PExt, QExt, PArg, QArg>::translate_ext(e, t)?)
-                }
-                CovenantExt::Introspect(e) => {
-                    CovenantExt::Introspect(TranslateExt::<PExt, QExt, PArg, QArg>::translate_ext(
-                        e, t,
-                    )?)
-                }
-            };
-        Ok(ext)
+        t.ext(self)
     }
 }
 

--- a/src/extensions/outputs_pref.rs
+++ b/src/extensions/outputs_pref.rs
@@ -8,7 +8,7 @@ use elements::encode::serialize;
 use elements::hashes::hex::{FromHex, ToHex};
 use elements::hashes::{sha256d, Hash};
 
-use super::{ExtParam, ParseableExt, TxEnv};
+use super::{ParseableExt, TxEnv};
 use crate::descriptor::CovError;
 use crate::miniscript::astelem::StackCtxOperations;
 use crate::miniscript::context::ScriptContextError;
@@ -19,8 +19,8 @@ use crate::miniscript::types::extra_props::{OpLimits, TimelockInfo};
 use crate::miniscript::types::{Base, Correctness, Dissat, ExtData, Input, Malleability};
 use crate::policy::{self, Liftable};
 use crate::{
-    expression, interpreter, Error, ExtTranslator, Extension, MiniscriptKey, Satisfier,
-    ToPublicKey, TranslateExt,
+    expression, interpreter, Error, Extension, MiniscriptKey, Satisfier,
+    ToPublicKey
 };
 
 /// Prefix is initally encoded in the script pubkey
@@ -280,25 +280,6 @@ impl ParseableExt for LegacyOutputsPref {
                 actual: hash_outputs.len(),
             })
         }
-    }
-}
-
-impl<PExt, QExt, PArg, QArg> TranslateExt<PExt, QExt, PArg, QArg> for LegacyOutputsPref
-where
-    PExt: Extension,
-    QExt: Extension,
-    PArg: ExtParam,
-    QArg: ExtParam,
-{
-    type Output = LegacyOutputsPref;
-
-    fn translate_ext<T, E>(&self, _t: &mut T) -> Result<Self::Output, E>
-    where
-        T: ExtTranslator<PArg, QArg, E>,
-    {
-        Ok(Self {
-            pref: self.pref.clone(),
-        })
     }
 }
 

--- a/src/extensions/outputs_pref.rs
+++ b/src/extensions/outputs_pref.rs
@@ -18,10 +18,7 @@ use crate::miniscript::satisfy::{Satisfaction, Witness};
 use crate::miniscript::types::extra_props::{OpLimits, TimelockInfo};
 use crate::miniscript::types::{Base, Correctness, Dissat, ExtData, Input, Malleability};
 use crate::policy::{self, Liftable};
-use crate::{
-    expression, interpreter, Error, Extension, MiniscriptKey, Satisfier,
-    ToPublicKey
-};
+use crate::{expression, interpreter, Error, Extension, MiniscriptKey, Satisfier, ToPublicKey};
 
 /// Prefix is initally encoded in the script pubkey
 /// User provides a suffix such that hash of (prefix || suffix)

--- a/src/extensions/param.rs
+++ b/src/extensions/param.rs
@@ -1,0 +1,178 @@
+//! Parameters to certain covenants
+
+use std::{hash, fmt};
+
+use bitcoin::hashes::hex::ToHex;
+use elements::confidential;
+use elements::encode::serialize;
+
+use crate::Error;
+use super::csfs::{CsfsKey, CsfsMsg};
+use super::introspect_ops::Spk;
+
+/// Trait for parsing extension arg from String
+/// Parse an argument from `s` given context of parent and argument position
+///
+/// When parsing all allowed parameters from string, we need to restrict where
+/// the parameters can be allowed. For example, csfs() should not have a txout
+/// parameter.
+///
+/// All parameters that should be parsed from extensions need to implement this
+pub trait ArgFromStr: Sized {
+    /// Parse an argument from `s` given context of parent and argument position
+    fn arg_from_str(s: &str, parent: &str, pos: usize) -> Result<Self, Error>;
+}
+
+/// Abstract parameter to Miniscript Extension
+pub trait ExtParam: Clone + Eq + Ord + fmt::Debug + fmt::Display + hash::Hash + ArgFromStr {}
+
+impl<T> ExtParam for T where
+    T: Clone + Eq + Ord + fmt::Debug + fmt::Display + hash::Hash + ArgFromStr
+{
+}
+
+impl ArgFromStr for String {
+    fn arg_from_str(s: &str, _parent: &str, _pos: usize) -> Result<Self, Error> {
+        // Abstract strings are parsed without context as they don't contain any concrete
+        // information
+        Ok(String::from(s))
+    }
+}
+
+
+/// No Extensions for elements-miniscript
+/// All the implementations for the this function are unreachable
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy, Hash)]
+pub enum NoExtParam {}
+
+impl fmt::Display for NoExtParam {
+    fn fmt(&self, _f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match *self {}
+    }
+}
+
+impl ArgFromStr for NoExtParam {
+    fn arg_from_str(_s: &str, _parent: &str, _pos: usize) -> Result<Self, Error> {
+        // This will be removed in a followup commit
+        unreachable!("Called ArgFromStr for NoExt")
+    }
+}
+
+/// All known Extension parameters/arguments
+#[derive(Debug, PartialEq, Eq, Clone, Hash)]
+pub enum CovExtArgs {
+    /// XOnlyPublicKey (in CSFS)
+    XOnlyKey(CsfsKey),
+    /// Message
+    CsfsMsg(CsfsMsg),
+    /// Asset
+    Asset(confidential::Asset),
+    /// Value
+    Value(confidential::Value),
+    /// Script
+    Script(Spk),
+}
+
+impl From<CsfsMsg> for CovExtArgs {
+    fn from(v: CsfsMsg) -> Self {
+        Self::CsfsMsg(v)
+    }
+}
+
+impl From<Spk> for CovExtArgs {
+    fn from(v: Spk) -> Self {
+        Self::Script(v)
+    }
+}
+
+impl From<confidential::Value> for CovExtArgs {
+    fn from(v: confidential::Value) -> Self {
+        Self::Value(v)
+    }
+}
+
+impl From<confidential::Asset> for CovExtArgs {
+    fn from(v: confidential::Asset) -> Self {
+        Self::Asset(v)
+    }
+}
+
+impl From<CsfsKey> for CovExtArgs {
+    fn from(v: CsfsKey) -> Self {
+        Self::XOnlyKey(v)
+    }
+}
+
+impl CovExtArgs {
+    /// Creates a new csfs key variant of [`CovExtArgs`]
+    pub fn csfs_key(key: bitcoin::XOnlyPublicKey) -> Self {
+        CovExtArgs::XOnlyKey(CsfsKey(key))
+    }
+
+    /// Creates a csfs message variant of [`CovExtArgs`]
+    pub fn csfs_msg(msg: elements::secp256k1_zkp::Message) -> Self {
+        CovExtArgs::CsfsMsg(CsfsMsg::new(msg.as_ref().to_vec()).expect("32 byte size message"))
+    }
+
+    /// Creates a new asset variant of [`CovExtArgs`]
+    pub fn asset(asset: confidential::Asset) -> Self {
+        Self::from(asset)
+    }
+
+    /// Creates a new value variant of [`CovExtArgs`]
+    pub fn value(value: confidential::Value) -> Self {
+        Self::from(value)
+    }
+
+    /// Creates a new script pubkey of [`CovExtArgs`]
+    pub fn spk(spk: elements::Script) -> Self {
+        Self::from(Spk(spk))
+    }
+}
+
+impl PartialOrd for CovExtArgs {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        // HACKY implementation, need Ord/PartialOrd to make it work with other components
+        // in the library
+        self.to_string().partial_cmp(&other.to_string())
+    }
+}
+
+impl Ord for CovExtArgs {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // HACKY implementation, need Ord/PartialOrd to make it work with other components
+        // in the library
+        self.to_string().cmp(&other.to_string())
+    }
+}
+
+impl fmt::Display for CovExtArgs {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            CovExtArgs::XOnlyKey(x) => write!(f, "{}", x),
+            CovExtArgs::CsfsMsg(m) => write!(f, "{}", m),
+            CovExtArgs::Asset(a) => write!(f, "{}", serialize(a).to_hex()),
+            CovExtArgs::Value(v) => write!(f, "{}", serialize(v).to_hex()),
+            CovExtArgs::Script(s) => write!(f, "{}", s),
+        }
+    }
+}
+
+impl ArgFromStr for CovExtArgs {
+    fn arg_from_str(s: &str, parent: &str, pos: usize) -> Result<Self, Error> {
+        let arg = match (parent, pos) {
+            ("csfs", 0) => CovExtArgs::XOnlyKey(CsfsKey::arg_from_str(s, parent, pos)?),
+            ("csfs", 1) => CovExtArgs::CsfsMsg(CsfsMsg::arg_from_str(s, parent, pos)?),
+            ("asset_eq", 0) | ("asset_eq", 1) | ("is_exp_asset", 0) => {
+                CovExtArgs::Asset(confidential::Asset::arg_from_str(s, parent, pos)?)
+            }
+            ("value_eq", 0) | ("value_eq", 1) | ("is_exp_value", 0) => {
+                CovExtArgs::Value(confidential::Value::arg_from_str(s, parent, pos)?)
+            }
+            ("spk_eq", 0) | ("spk_eq", 1) => CovExtArgs::Script(Spk::arg_from_str(s, parent, pos)?),
+            _ => return Err(Error::Unexpected(s.to_string())),
+        };
+        Ok(arg)
+    }
+}
+

--- a/src/extensions/param.rs
+++ b/src/extensions/param.rs
@@ -1,15 +1,15 @@
 //! Parameters to certain covenants
 
-use std::{hash, fmt};
+use std::{fmt, hash};
 
 use bitcoin::hashes::hex::ToHex;
 use elements::confidential;
 use elements::encode::serialize;
 
-use crate::{Error, ExtTranslator};
-use super::CovenantExt;
 use super::csfs::{CsfsKey, CsfsMsg};
 use super::introspect_ops::Spk;
+use super::CovenantExt;
+use crate::{Error, ExtTranslator};
 
 /// Trait for parsing extension arg from String
 /// Parse an argument from `s` given context of parent and argument position
@@ -39,7 +39,6 @@ impl ArgFromStr for String {
         Ok(String::from(s))
     }
 }
-
 
 /// No Extensions for elements-miniscript
 /// All the implementations for the this function are unreachable
@@ -199,13 +198,16 @@ where
         match *cov {
             CovenantExt::LegacyVerEq(ref v) => Ok(CovenantExt::LegacyVerEq(v.clone())),
             CovenantExt::LegacyOutputsPref(ref p) => Ok(CovenantExt::LegacyOutputsPref(p.clone())),
-            CovenantExt::Csfs(ref c) => Ok(CovenantExt::Csfs(TranslateExtParam::translate_ext(c, self)?)),
+            CovenantExt::Csfs(ref c) => Ok(CovenantExt::Csfs(TranslateExtParam::translate_ext(
+                c, self,
+            )?)),
             CovenantExt::Arith(ref e) => Ok(CovenantExt::Arith(e.clone())),
-            CovenantExt::Introspect(ref c) => Ok(CovenantExt::Introspect(TranslateExtParam::translate_ext(c, self)?)),
+            CovenantExt::Introspect(ref c) => Ok(CovenantExt::Introspect(
+                TranslateExtParam::translate_ext(c, self)?,
+            )),
         }
     }
 }
-
 
 /// Converts a descriptor using abstract extension parameters to one using concrete ones,
 /// or vice-versa
@@ -223,4 +225,3 @@ where
     where
         T: ExtParamTranslator<PArg, QArg, E>;
 }
-

--- a/src/extensions/tx_ver.rs
+++ b/src/extensions/tx_ver.rs
@@ -6,7 +6,7 @@ use std::fmt;
 
 use elements::encode::serialize;
 
-use super::{ExtParam, ParseableExt, TxEnv};
+use super::{ParseableExt, TxEnv};
 use crate::descriptor::CovError;
 use crate::miniscript::astelem::StackCtxOperations;
 use crate::miniscript::lex::{Token as Tk, TokenIter};
@@ -15,8 +15,8 @@ use crate::miniscript::types::extra_props::{OpLimits, TimelockInfo};
 use crate::miniscript::types::{Base, Correctness, Dissat, ExtData, Input, Malleability};
 use crate::policy::{self, Liftable};
 use crate::{
-    expression, interpreter, miniscript, util, Error, ExtTranslator, Extension, MiniscriptKey,
-    Satisfier, ToPublicKey, TranslateExt,
+    expression, interpreter, miniscript, util, Error, Extension, MiniscriptKey,
+    Satisfier, ToPublicKey,
 };
 
 /// Version struct
@@ -187,23 +187,6 @@ impl ParseableExt for LegacyVerEq {
                 actual: elem.len(),
             })
         }
-    }
-}
-
-impl<PExt, QExt, PArg, QArg> TranslateExt<PExt, QExt, PArg, QArg> for LegacyVerEq
-where
-    PExt: Extension,
-    QExt: Extension,
-    PArg: ExtParam,
-    QArg: ExtParam,
-{
-    type Output = LegacyVerEq;
-
-    fn translate_ext<T, E>(&self, _t: &mut T) -> Result<Self::Output, E>
-    where
-        T: ExtTranslator<PArg, QArg, E>,
-    {
-        Ok(Self { n: self.n })
     }
 }
 

--- a/src/extensions/tx_ver.rs
+++ b/src/extensions/tx_ver.rs
@@ -15,8 +15,8 @@ use crate::miniscript::types::extra_props::{OpLimits, TimelockInfo};
 use crate::miniscript::types::{Base, Correctness, Dissat, ExtData, Input, Malleability};
 use crate::policy::{self, Liftable};
 use crate::{
-    expression, interpreter, miniscript, util, Error, Extension, MiniscriptKey,
-    Satisfier, ToPublicKey,
+    expression, interpreter, miniscript, util, Error, Extension, MiniscriptKey, Satisfier,
+    ToPublicKey,
 };
 
 /// Version struct

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -518,7 +518,7 @@ where
     /// x-only keys are translated to [`bitcoin::PublicKey`] with 0x02 prefix.
     pub fn inferred_descriptor(
         &self,
-    ) -> Result<Descriptor<bitcoin::PublicKey, CovExtArgs>, crate::Error> {
+    ) -> Result<Descriptor<bitcoin::PublicKey, CovenantExt<CovExtArgs>>, crate::Error> {
         Descriptor::from_str(&self.inferred_descriptor_string())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,6 @@ pub(crate) use bitcoin_miniscript::{
 pub use bitcoin_miniscript::{
     DummyKey, DummyKeyHash, ForEach, ForEachKey, MiniscriptKey, ToPublicKey,
 };
-use extensions::ExtParam;
 // End imports
 
 #[macro_use]
@@ -225,13 +224,13 @@ where
 }
 
 /// Trait for translation Extensions
-pub trait ExtTranslator<PArg, QArg, E>
+pub trait ExtTranslator<PExt, QExt, E>
 where
-    PArg: ExtParam,
-    QArg: ExtParam,
+    PExt: Extension,
+    QExt: Extension,
 {
     /// Translates one extension to another
-    fn ext(&mut self, e: &PArg) -> Result<QArg, E>;
+    fn ext(&mut self, e: &PExt) -> Result<QExt, E>;
 }
 
 /// Converts a descriptor using abstract keys to one using specific keys. Uses translator `t` to do
@@ -253,12 +252,10 @@ where
 
 /// Converts a descriptor using abstract keys to one using specific keys. Uses translator `t` to do
 /// the actual translation function calls.
-pub trait TranslateExt<PExt, QExt, PArg, QArg>
+pub trait TranslateExt<PExt, QExt>
 where
     PExt: Extension,
     QExt: Extension,
-    PArg: ExtParam,
-    QArg: ExtParam,
 {
     /// The associated output type.
     type Output;
@@ -267,7 +264,7 @@ where
     /// for Pk are provided by the given [`Translator`].
     fn translate_ext<T, E>(&self, translator: &mut T) -> Result<Self::Output, E>
     where
-        T: ExtTranslator<PArg, QArg, E>;
+        T: ExtTranslator<PExt, QExt, E>;
 }
 
 /// Miniscript Error

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -315,8 +315,7 @@ where
     }
 }
 
-impl<Pk, Ctx, Ext, ExtQ> TranslateExt<Ext, ExtQ>
-    for Miniscript<Pk, Ctx, Ext>
+impl<Pk, Ctx, Ext, ExtQ> TranslateExt<Ext, ExtQ> for Miniscript<Pk, Ctx, Ext>
 where
     Pk: MiniscriptKey,
     Ctx: ScriptContext,

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -47,7 +47,7 @@ use std::sync::Arc;
 
 use self::lex::{lex, TokenIter};
 use self::types::Property;
-use crate::extensions::{ExtParam, ParseableExt};
+use crate::extensions::ParseableExt;
 pub use crate::miniscript::context::ScriptContext;
 use crate::miniscript::decode::Terminal;
 use crate::miniscript::types::extra_props::ExtData;
@@ -315,21 +315,19 @@ where
     }
 }
 
-impl<Pk, Ctx, Ext, ExtQ, PArg, QArg> TranslateExt<Ext, ExtQ, PArg, QArg>
+impl<Pk, Ctx, Ext, ExtQ> TranslateExt<Ext, ExtQ>
     for Miniscript<Pk, Ctx, Ext>
 where
     Pk: MiniscriptKey,
     Ctx: ScriptContext,
-    Ext: Extension + TranslateExt<Ext, ExtQ, PArg, QArg, Output = ExtQ>,
+    Ext: Extension + TranslateExt<Ext, ExtQ, Output = ExtQ>,
     ExtQ: Extension,
-    PArg: ExtParam,
-    QArg: ExtParam,
 {
     type Output = Miniscript<Pk, Ctx, ExtQ>;
 
     fn translate_ext<T, E>(&self, t: &mut T) -> Result<Self::Output, E>
     where
-        T: ExtTranslator<PArg, QArg, E>,
+        T: ExtTranslator<Ext, ExtQ, E>,
     {
         self.real_translate_ext(t)
     }
@@ -367,16 +365,14 @@ impl<Pk: MiniscriptKey, Ctx: ScriptContext, Ext: Extension> Miniscript<Pk, Ctx, 
         Ok(ms)
     }
 
-    pub(super) fn real_translate_ext<T, FuncError, ExtQ, PArg, QArg>(
+    pub(super) fn real_translate_ext<T, FuncError, ExtQ>(
         &self,
         t: &mut T,
     ) -> Result<Miniscript<Pk, Ctx, ExtQ>, FuncError>
     where
         ExtQ: Extension,
-        T: ExtTranslator<PArg, QArg, FuncError>,
-        PArg: ExtParam,
-        QArg: ExtParam,
-        Ext: TranslateExt<Ext, ExtQ, PArg, QArg, Output = ExtQ>,
+        T: ExtTranslator<Ext, ExtQ, FuncError>,
+        Ext: TranslateExt<Ext, ExtQ, Output = ExtQ>,
     {
         let inner = self.node.real_translate_ext(t)?;
         let ms = Miniscript {

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -28,6 +28,7 @@ use {
     crate::policy::compiler::CompilerError,
     crate::policy::compiler::OrdF64,
     crate::policy::{compiler, Concrete, Liftable, Semantic},
+    crate::CovenantExt,
     crate::Descriptor,
     crate::Miniscript,
     crate::NoExt,
@@ -266,7 +267,7 @@ impl<Pk: MiniscriptKey> Policy<Pk> {
     pub fn compile_tr(
         &self,
         unspendable_key: Option<Pk>,
-    ) -> Result<Descriptor<Pk, NoExtParam>, Error> {
+    ) -> Result<Descriptor<Pk, CovenantExt<NoExtParam>>, Error> {
         self.is_valid()?; // Check for validity
         match self.is_safe_nonmalleable() {
             (false, _) => Err(Error::from(CompilerError::TopLevelNonSafe)),

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -21,7 +21,6 @@
 //! The format represents EC public keys abstractly to allow wallets to replace
 //! these with BIP32 paths, pay-to-contract instructions, etc.
 //!
-use crate::extensions::ExtParam;
 use crate::{error, fmt};
 
 #[cfg(feature = "compiler")]
@@ -179,7 +178,7 @@ where
     }
 }
 
-impl<Pk: MiniscriptKey, T: ExtParam> Liftable<Pk> for Descriptor<Pk, T> {
+impl<Pk: MiniscriptKey, T: Extension> Liftable<Pk> for Descriptor<Pk, T> {
     fn lift(&self) -> Result<Semantic<Pk>, Error> {
         match *self {
             Descriptor::Bare(ref bare) => bare.lift(),

--- a/src/psbt/finalizer.rs
+++ b/src/psbt/finalizer.rs
@@ -148,7 +148,7 @@ pub(super) fn prevouts(psbt: &Psbt) -> Result<Vec<elements::TxOut>, super::Error
 pub(super) fn get_descriptor(
     psbt: &Psbt,
     index: usize,
-) -> Result<Descriptor<PublicKey, CovExtArgs>, InputError> {
+) -> Result<Descriptor<PublicKey, CovenantExt<CovExtArgs>>, InputError> {
     // Figure out Scriptpubkey
     let script_pubkey = get_scriptpubkey(psbt, index)?;
     let inp = &psbt.inputs()[index];

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -32,7 +32,7 @@ use elements::sighash::SigHashCache;
 use elements::taproot::{self, ControlBlock, LeafVersion, TapLeafHash};
 use elements::{self, EcdsaSigHashType, SchnorrSigHashType, Script};
 
-use crate::extensions::{CovExtArgs, ParseableExt};
+use crate::extensions::{CovenantExt, CovExtArgs, ParseableExt};
 use crate::miniscript::iter::PkPkh;
 use crate::miniscript::limits::SEQUENCE_LOCKTIME_DISABLE_FLAG;
 use crate::miniscript::satisfy::{elementssig_from_rawsig, After, Older};
@@ -592,7 +592,7 @@ pub trait PsbtExt {
     fn update_input_with_descriptor(
         &mut self,
         input_index: usize,
-        descriptor: &Descriptor<DescriptorPublicKey, CovExtArgs>,
+        descriptor: &Descriptor<DescriptorPublicKey, CovenantExt<CovExtArgs>>,
     ) -> Result<(), UtxoUpdateError>;
 
     /// Get the sighash message(data to sign) at input index `idx` based on the sighash
@@ -769,7 +769,7 @@ impl PsbtExt for Psbt {
     fn update_input_with_descriptor(
         &mut self,
         input_index: usize,
-        desc: &Descriptor<DescriptorPublicKey, CovExtArgs>,
+        desc: &Descriptor<DescriptorPublicKey, CovenantExt<CovExtArgs>>,
     ) -> Result<(), UtxoUpdateError> {
         let n_inputs = self.inputs().len();
         let input = self
@@ -963,15 +963,15 @@ pub trait PsbtInputExt {
     /// [`update_input_with_descriptor`]: PsbtExt::update_input_with_descriptor
     fn update_with_descriptor_unchecked(
         &mut self,
-        descriptor: &Descriptor<DescriptorPublicKey, CovExtArgs>,
-    ) -> Result<Descriptor<bitcoin::PublicKey, CovExtArgs>, descriptor::ConversionError>;
+        descriptor: &Descriptor<DescriptorPublicKey, CovenantExt<CovExtArgs>>,
+    ) -> Result<Descriptor<bitcoin::PublicKey, CovenantExt<CovExtArgs>>, descriptor::ConversionError>;
 }
 
 impl PsbtInputExt for psbt::Input {
     fn update_with_descriptor_unchecked(
         &mut self,
-        descriptor: &Descriptor<DescriptorPublicKey, CovExtArgs>,
-    ) -> Result<Descriptor<bitcoin::PublicKey, CovExtArgs>, descriptor::ConversionError> {
+        descriptor: &Descriptor<DescriptorPublicKey, CovenantExt<CovExtArgs>>,
+    ) -> Result<Descriptor<bitcoin::PublicKey, CovenantExt<CovExtArgs>>, descriptor::ConversionError> {
         let (derived, _) = update_input_with_descriptor_helper(self, descriptor, None)?;
         Ok(derived)
     }
@@ -1052,12 +1052,12 @@ impl Translator<DescriptorPublicKey, bitcoin::PublicKey, descriptor::ConversionE
 
 fn update_input_with_descriptor_helper(
     input: &mut psbt::Input,
-    descriptor: &Descriptor<DescriptorPublicKey, CovExtArgs>,
+    descriptor: &Descriptor<DescriptorPublicKey, CovenantExt<CovExtArgs>>,
     check_script: Option<Script>,
     // the return value is a tuple here since the two internal calls to it require different info.
     // One needs the derived descriptor and the other needs to know whether the script_pubkey check
     // failed.
-) -> Result<(Descriptor<bitcoin::PublicKey, CovExtArgs>, bool), descriptor::ConversionError> {
+) -> Result<(Descriptor<bitcoin::PublicKey, CovenantExt<CovExtArgs>>, bool), descriptor::ConversionError> {
     let secp = secp256k1::Secp256k1::verification_only();
 
     let derived = if let Descriptor::Tr(_) = &descriptor {

--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -32,7 +32,7 @@ use elements::sighash::SigHashCache;
 use elements::taproot::{self, ControlBlock, LeafVersion, TapLeafHash};
 use elements::{self, EcdsaSigHashType, SchnorrSigHashType, Script};
 
-use crate::extensions::{CovenantExt, CovExtArgs, ParseableExt};
+use crate::extensions::{CovExtArgs, CovenantExt, ParseableExt};
 use crate::miniscript::iter::PkPkh;
 use crate::miniscript::limits::SEQUENCE_LOCKTIME_DISABLE_FLAG;
 use crate::miniscript::satisfy::{elementssig_from_rawsig, After, Older};
@@ -971,7 +971,8 @@ impl PsbtInputExt for psbt::Input {
     fn update_with_descriptor_unchecked(
         &mut self,
         descriptor: &Descriptor<DescriptorPublicKey, CovenantExt<CovExtArgs>>,
-    ) -> Result<Descriptor<bitcoin::PublicKey, CovenantExt<CovExtArgs>>, descriptor::ConversionError> {
+    ) -> Result<Descriptor<bitcoin::PublicKey, CovenantExt<CovExtArgs>>, descriptor::ConversionError>
+    {
         let (derived, _) = update_input_with_descriptor_helper(self, descriptor, None)?;
         Ok(derived)
     }
@@ -1057,7 +1058,13 @@ fn update_input_with_descriptor_helper(
     // the return value is a tuple here since the two internal calls to it require different info.
     // One needs the derived descriptor and the other needs to know whether the script_pubkey check
     // failed.
-) -> Result<(Descriptor<bitcoin::PublicKey, CovenantExt<CovExtArgs>>, bool), descriptor::ConversionError> {
+) -> Result<
+    (
+        Descriptor<bitcoin::PublicKey, CovenantExt<CovExtArgs>>,
+        bool,
+    ),
+    descriptor::ConversionError,
+> {
     let secp = secp256k1::Secp256k1::verification_only();
 
     let derived = if let Descriptor::Tr(_) = &descriptor {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -162,4 +162,3 @@ impl ExtParamTranslator<String, CovExtArgs, ()> for StrExtTranslator {
         Ok(x.clone())
     }
 }
-

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -162,3 +162,4 @@ impl ExtParamTranslator<String, CovExtArgs, ()> for StrExtTransalator {
         Ok(x.clone())
     }
 }
+

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -6,8 +6,8 @@ use std::str::FromStr;
 use bitcoin::hashes::{hash160, sha256};
 use bitcoin::secp256k1;
 
-use crate::extensions::CovExtArgs;
-use crate::{ExtTranslator, MiniscriptKey, Translator};
+use crate::extensions::{param::ExtParamTranslator, CovExtArgs};
+use crate::{MiniscriptKey, Translator};
 
 /// Translate from a String MiniscriptKey type to bitcoin::PublicKey
 /// If the hashmap is populated, this will lookup for keys in HashMap
@@ -156,7 +156,7 @@ pub struct StrExtTransalator {
     pub ext_map: HashMap<String, CovExtArgs>,
 }
 
-impl ExtTranslator<String, CovExtArgs, ()> for StrExtTransalator {
+impl ExtParamTranslator<String, CovExtArgs, ()> for StrExtTransalator {
     fn ext(&mut self, e: &String) -> Result<CovExtArgs, ()> {
         let x = self.ext_map.get(e).expect("Ext Mapping not found");
         Ok(x.clone())

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -152,11 +152,11 @@ impl StrXOnlyKeyTranslator {
 
 /// Translate Abstract Str to Consensus Extensions
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
-pub struct StrExtTransalator {
+pub struct StrExtTranslator {
     pub ext_map: HashMap<String, CovExtArgs>,
 }
 
-impl ExtParamTranslator<String, CovExtArgs, ()> for StrExtTransalator {
+impl ExtParamTranslator<String, CovExtArgs, ()> for StrExtTranslator {
     fn ext(&mut self, e: &String) -> Result<CovExtArgs, ()> {
         let x = self.ext_map.get(e).expect("Ext Mapping not found");
         Ok(x.clone())

--- a/tests/setup/test_util.rs
+++ b/tests/setup/test_util.rs
@@ -180,9 +180,9 @@ pub fn parse_insane_ms<Ctx: ScriptContext>(
 }
 
 /// Translate Abstract Str to Consensus Extensions
-struct StrExtTransalator<'a>(usize, &'a PubData);
+struct StrExtTranslator<'a>(usize, &'a PubData);
 
-impl<'a> ExtParamTranslator<String, CovExtArgs, ()> for StrExtTransalator<'a> {
+impl<'a> ExtParamTranslator<String, CovExtArgs, ()> for StrExtTranslator<'a> {
     fn ext(&mut self, e: &String) -> Result<CovExtArgs, ()> {
         if e.starts_with("msg") {
             Ok(CovExtArgs::CsfsMsg(self.1.msg.clone()))
@@ -313,7 +313,7 @@ pub fn parse_test_desc(desc: &str, pubdata: &PubData) -> Descriptor<DescriptorPu
     let desc = Descriptor::<String, CovenantExt<String>>::from_str(&desc)
         .expect("only parsing valid and sane descriptors");
     let mut translator = StrDescPubKeyTranslator(0, pubdata);
-    let mut ext_trans = StrExtTransalator(0, pubdata);
+    let mut ext_trans = StrExtTranslator(0, pubdata);
     let desc: Result<_, ()> = desc.translate_pk(&mut translator);
     let desc = desc.expect("Translate Keys must succeed");
     let desc: Result<_, ()> = desc.translate_ext(&mut ext_trans);

--- a/tests/setup/test_util.rs
+++ b/tests/setup/test_util.rs
@@ -26,9 +26,9 @@ use bitcoin::secp256k1;
 use elements::hashes::hex::FromHex;
 use elements::{confidential, encode, AddressParams, BlockHash};
 use miniscript::descriptor::{SinglePub, SinglePubKey};
-use miniscript::extensions::{CovExtArgs, CsfsKey, CsfsMsg};
+use miniscript::extensions::{param::ExtParamTranslator, CovExtArgs, CsfsKey, CsfsMsg};
 use miniscript::{
-    Descriptor, DescriptorPublicKey, ExtTranslator, Miniscript, ScriptContext, TranslateExt,
+    CovenantExt, Descriptor, DescriptorPublicKey, Miniscript, ScriptContext, TranslateExt,
     TranslatePk, Translator,
 };
 use rand::RngCore;
@@ -182,7 +182,7 @@ pub fn parse_insane_ms<Ctx: ScriptContext>(
 /// Translate Abstract Str to Consensus Extensions
 struct StrExtTransalator<'a>(usize, &'a PubData);
 
-impl<'a> ExtTranslator<String, CovExtArgs, ()> for StrExtTransalator<'a> {
+impl<'a> ExtParamTranslator<String, CovExtArgs, ()> for StrExtTransalator<'a> {
     fn ext(&mut self, e: &String) -> Result<CovExtArgs, ()> {
         if e.starts_with("msg") {
             Ok(CovExtArgs::CsfsMsg(self.1.msg.clone()))
@@ -310,7 +310,7 @@ impl<'a> Translator<String, DescriptorPublicKey, ()> for StrTranslatorLoose<'a> 
 // https://github.com/rust-lang/rust/issues/46379. The code is pub fn and integration test, but still shows warnings
 pub fn parse_test_desc(desc: &str, pubdata: &PubData) -> Descriptor<DescriptorPublicKey> {
     let desc = subs_hash_frag(desc, pubdata);
-    let desc = Descriptor::<String, String>::from_str(&desc)
+    let desc = Descriptor::<String, CovenantExt<String>>::from_str(&desc)
         .expect("only parsing valid and sane descriptors");
     let mut translator = StrDescPubKeyTranslator(0, pubdata);
     let mut ext_trans = StrExtTransalator(0, pubdata);


### PR DESCRIPTION
The existing code made `Descriptor` generic over `ExtParam` rather than `Extension`. This made the `Extension` trati basically useless since every `Descriptor` always had `CovenantExt` as its extension type.

It also caused me a lot of confusion because I tried to call the `address` method on a `Descriptor<Pk, NoExt>`, which I was able to parse, just not call any methods on. I pulled on this string and 1000 lines later here we are.