### PR TITLE
update miniscript dependency to 9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ rand = ["bitcoin/rand"]
 [dependencies]
 bitcoin = "0.29.1"
 elements = "0.21.0"
-bitcoin-miniscript = {package = "miniscript", git = "https://github.com/rust-bitcoin/rust-miniscript", rev = "fd9ef55f894e9de2705822e801ac08cc563fc06a"}
+bitcoin-miniscript = { package = "miniscript", version = "9.0" }
 
 # Do NOT use this as a feature! Use the `serde` feature instead.
 actual-serde = { package = "serde", version = "1.0", optional = true }

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ cargo update --package url --precise 2.2.2
 cargo update --package form_urlencoded --precise 1.0.1
 cargo update -p once_cell --precise 1.13.1
 cargo update -p bzip2 --precise 0.4.2
+cargo update -p which --precise 4.3.0
 ```
 
 ## Contributing

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -26,6 +26,7 @@ if [ "$MSRV" = true ]; then
     cargo update -p form_urlencoded --precise 1.0.1
     cargo update -p once_cell --precise 1.13.1
     cargo update -p bzip2 --precise 0.4.2
+    cargo update -p which --precise 4.3.0
 fi
 
 # Format if told to

--- a/fuzz/fuzz_targets/compile_descriptor.rs
+++ b/fuzz/fuzz_targets/compile_descriptor.rs
@@ -1,13 +1,13 @@
 extern crate elements_miniscript as miniscript;
 
 use miniscript::Segwitv0;
-use miniscript::{policy, DummyKey, Miniscript};
+use miniscript::{policy, Miniscript};
 use policy::Liftable;
 
 use std::str::FromStr;
 
-type DummyScript = Miniscript<DummyKey, Segwitv0>;
-type DummyPolicy = policy::Concrete<DummyKey>;
+type DummyScript = Miniscript<String, Segwitv0>;
+type DummyPolicy = policy::Concrete<String>;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);

--- a/fuzz/fuzz_targets/roundtrip_concrete.rs
+++ b/fuzz/fuzz_targets/roundtrip_concrete.rs
@@ -1,10 +1,10 @@
 extern crate elements_miniscript as miniscript;
 extern crate regex;
-use miniscript::{policy, DummyKey};
+use miniscript::policy;
 use regex::Regex;
 use std::str::FromStr;
 
-type DummyPolicy = policy::Concrete<DummyKey>;
+type DummyPolicy = policy::Concrete<String>;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);

--- a/fuzz/fuzz_targets/roundtrip_descriptor.rs
+++ b/fuzz/fuzz_targets/roundtrip_descriptor.rs
@@ -1,7 +1,7 @@
 extern crate elements_miniscript as miniscript;
 extern crate regex;
 
-use miniscript::{Descriptor, DummyKey};
+use miniscript::Descriptor;
 use regex::Regex;
 use std::str::FromStr;
 
@@ -10,9 +10,9 @@ fn do_test(data: &[u8]) {
     // for alias like t: and_v(1), likely and unlikely.
     // Just directly check whether the inferred descriptor is the same.
     let s = String::from_utf8_lossy(data);
-    if let Ok(desc) = Descriptor::<DummyKey>::from_str(&s) {
+    if let Ok(desc) = Descriptor::<String>::from_str(&s) {
         let str2 = desc.to_string();
-        let desc2 = Descriptor::<DummyKey>::from_str(&str2).unwrap();
+        let desc2 = Descriptor::<String>::from_str(&str2).unwrap();
 
         assert_eq!(desc.to_string(), desc2.to_string());
     }

--- a/fuzz/fuzz_targets/roundtrip_miniscript_str.rs
+++ b/fuzz/fuzz_targets/roundtrip_miniscript_str.rs
@@ -5,16 +5,15 @@ use regex::Regex;
 use std::str::FromStr;
 
 use miniscript::CovenantExt;
-use miniscript::DummyKey;
 use miniscript::Miniscript;
 use miniscript::NoExt;
 use miniscript::Segwitv0;
 
 fn do_test(data: &[u8]) {
     let s = String::from_utf8_lossy(data);
-    if let Ok(desc) = Miniscript::<DummyKey, Segwitv0, NoExt>::from_str(&s) {
+    if let Ok(desc) = Miniscript::<String, Segwitv0, NoExt>::from_str(&s) {
         let str2 = desc.to_string();
-        let desc2 = Miniscript::<DummyKey, Segwitv0, NoExt>::from_str(&str2).unwrap();
+        let desc2 = Miniscript::<String, Segwitv0, NoExt>::from_str(&str2).unwrap();
         assert_eq!(desc, desc2);
     }
 }

--- a/fuzz/fuzz_targets/roundtrip_semantic.rs
+++ b/fuzz/fuzz_targets/roundtrip_semantic.rs
@@ -1,9 +1,9 @@
 extern crate elements_miniscript as miniscript;
 
-use miniscript::{policy, DummyKey};
+use miniscript::policy;
 use std::str::FromStr;
 
-type DummyPolicy = policy::Semantic<DummyKey>;
+type DummyPolicy = policy::Semantic<String>;
 
 fn do_test(data: &[u8]) {
     let data_str = String::from_utf8_lossy(data);

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -1138,7 +1138,7 @@ mod tests {
     use crate::miniscript::satisfy::ElementsSig;
     #[cfg(feature = "compiler")]
     use crate::policy;
-    use crate::{hex_script, Descriptor, DummyKey, Error, Miniscript, NoExt, Satisfier};
+    use crate::{hex_script, Descriptor, Error, Miniscript, NoExt, Satisfier};
 
     type StdDescriptor = Descriptor<PublicKey, CovenantExt<CovExtArgs>>;
     const TEST_PK: &'static str =
@@ -1162,7 +1162,7 @@ mod tests {
     }
 
     fn roundtrip_descriptor(s: &str) {
-        let desc = Descriptor::<DummyKey>::from_str(&s).unwrap();
+        let desc = Descriptor::<String>::from_str(&s).unwrap();
         let output = desc.to_string();
         let normalize_aliases = s.replace("c:pk_k(", "pk(").replace("c:pk_h(", "pkh(");
         assert_eq!(
@@ -1203,7 +1203,7 @@ mod tests {
         StdDescriptor::from_str("(\u{7f}()3").unwrap_err();
         StdDescriptor::from_str("pk()").unwrap_err();
         StdDescriptor::from_str("nl:0").unwrap_err(); //issue 63
-        let compressed_pk = DummyKey.to_string();
+        let compressed_pk = "02be5645686309c6e6736dbd93940707cc9143d3cf29f1b877ff340e2cb2d259cf";
         assert_eq!(
             StdDescriptor::from_str("elsh(sortedmulti)")
                 .unwrap_err()
@@ -1574,13 +1574,13 @@ mod tests {
 
     #[test]
     fn tr_roundtrip_key() {
-        let script = Tr::<DummyKey>::from_str("eltr()").unwrap().to_string();
+        let script = Tr::<String>::from_str("eltr()").unwrap().to_string();
         assert_eq!(script, format!("eltr()#sux3r82e"))
     }
 
     #[test]
     fn tr_roundtrip_script() {
-        let descriptor = Tr::<DummyKey>::from_str("eltr(,{pk(),pk()})")
+        let descriptor = Tr::<String>::from_str("eltr(,{pk(),pk()})")
             .unwrap()
             .to_string();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,8 +125,7 @@ pub(crate) use bitcoin_miniscript::policy::semantic::Policy as BtcPolicy;
 pub(crate) use bitcoin_miniscript::policy::Liftable as BtcLiftable;
 // re-export imports
 pub use bitcoin_miniscript::{
-    hash256, DummyHash160Hash, DummyHash256Hash, DummyKey, DummyKeyHash, DummyRipemd160Hash,
-    DummySha256Hash, ForEachKey, MiniscriptKey, SigType, ToPublicKey,
+    hash256, ForEachKey, MiniscriptKey, SigType, ToPublicKey,
 };
 pub(crate) use bitcoin_miniscript::{
     Descriptor as BtcDescriptor, Error as BtcError, Miniscript as BtcMiniscript,

--- a/src/miniscript/mod.rs
+++ b/src/miniscript/mod.rs
@@ -549,7 +549,7 @@ mod tests {
     use crate::policy::Liftable;
     use crate::test_utils::{StrKeyTranslator, StrXOnlyKeyTranslator};
     use crate::{
-        hex_script, CovenantExt, DummyKey, ExtParams, NoExt, Satisfier, ToPublicKey, TranslatePk,
+        hex_script, CovenantExt, ExtParams, NoExt, Satisfier, ToPublicKey, TranslatePk,
     };
 
     type Tapscript = Miniscript<XOnlyPublicKey, Tap, NoExt>;
@@ -607,7 +607,7 @@ mod tests {
     }
 
     fn dummy_string_rtt<Ctx: ScriptContext>(
-        script: Miniscript<DummyKey, Ctx, NoExt>,
+        script: Miniscript<String, Ctx, NoExt>,
         expected_debug: &str,
         expected_display: &str,
     ) {
@@ -743,9 +743,9 @@ mod tests {
         .unwrap();
         let hash = hash160::Hash::from_inner([17; 20]);
 
-        let pkk_ms: Miniscript<DummyKey, Segwitv0> = Miniscript {
+        let pkk_ms: Miniscript<String, Segwitv0> = Miniscript {
             node: Terminal::Check(Arc::new(Miniscript {
-                node: Terminal::PkK(DummyKey),
+                node: Terminal::PkK("dummy".into()),
                 ty: Type::from_pk_k::<Segwitv0>(),
                 ext: types::extra_props::ExtData::from_pk_k::<Segwitv0>(),
                 phantom: PhantomData,
@@ -754,11 +754,11 @@ mod tests {
             ext: ExtData::cast_check(ExtData::from_pk_k::<Segwitv0>()).unwrap(),
             phantom: PhantomData,
         };
-        dummy_string_rtt(pkk_ms, "[B/onduesm]c:[K/onduesm]pk_k(DummyKey)", "pk()");
+        dummy_string_rtt(pkk_ms, "[B/onduesm]c:[K/onduesm]pk_k(\"dummy\")", "pk(dummy)");
 
-        let pkh_ms: Miniscript<DummyKey, Segwitv0> = Miniscript {
+        let pkh_ms: Miniscript<String, Segwitv0> = Miniscript {
             node: Terminal::Check(Arc::new(Miniscript {
-                node: Terminal::PkH(DummyKey),
+                node: Terminal::PkH("dummy".into()),
                 ty: Type::from_pk_h::<Segwitv0>(),
                 ext: types::extra_props::ExtData::from_pk_h::<Segwitv0>(),
                 phantom: PhantomData,
@@ -768,8 +768,8 @@ mod tests {
             phantom: PhantomData,
         };
 
-        let expected_debug = "[B/nduesm]c:[K/nduesm]pk_h(DummyKey)";
-        let expected_display = "pkh()";
+        let expected_debug = "[B/nduesm]c:[K/nduesm]pk_h(\"dummy\")";
+        let expected_display = "pkh(dummy)";
 
         assert_eq!(pkh_ms.ty.corr.base, types::Base::B);
         let debug = format!("{:?}", pkh_ms);

--- a/src/policy/mod.rs
+++ b/src/policy/mod.rs
@@ -273,12 +273,11 @@ mod tests {
     use super::{Concrete, Liftable, Semantic};
     #[cfg(feature = "compiler")]
     use crate::descriptor::Tr;
-    use crate::DummyKey;
     #[cfg(feature = "compiler")]
     use crate::{descriptor::TapTree, Descriptor, Tap};
 
-    type ConcretePol = Concrete<DummyKey>;
-    type SemanticPol = Semantic<DummyKey>;
+    type ConcretePol = Concrete<String>;
+    type SemanticPol = Semantic<String>;
 
     fn concrete_policy_rtt(s: &str) {
         let conc = ConcretePol::from_str(s).unwrap();


### PR DESCRIPTION
This was nearly trivial, just had to deal with the removal of the `Dummy*` types. Lets us depend on a release version of miniscript rather than a git commit.