### PR TITLE
Add Elements serde feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ compiler = []
 trace = []
 
 unstable = []
-serde = ["actual-serde", "bitcoin/serde"]
+serde = ["actual-serde", "bitcoin/serde", "elements/serde"]
 rand = ["bitcoin/rand"]
 base64 = ["bitcoin/base64"]
 


### PR DESCRIPTION
Useful when one uses the `elements` inside `elements-miniscript` instead of a separate dependency.