### PR TITLE
remove std feature gate on OutputUpdateError

### DIFF
--- a/src/psbt/mod.rs
+++ b/src/psbt/mod.rs
@@ -1433,7 +1433,6 @@ impl fmt::Display for OutputUpdateError {
     }
 }
 
-#[cfg(feature = "std")]
 impl error::Error for OutputUpdateError {
     fn cause(&self) -> Option<&dyn error::Error> {
         use self::OutputUpdateError::*;


### PR DESCRIPTION
It seems this feature gate is a refuse (since for example is not on `UtxoUpdateError`) and not implementing std::error::Error cause issues downstream