### PR TITLE
descriptor: drop `to_string_no_chksum` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- [Removed `to_string_no_chksum`](https://github.com/ElementsProject/elements-miniscript/pull/86). This method was poorly-named and broken. Use the alternate display `{:#}` formatter instead to format descriptors without a checksum.
+
 # 0.3.1 - May 10, 2024
 
 - [Fixed](https://github.com/ElementsProject/elements-miniscript/pull/81) ELIP-151 hash calculation

--- a/src/descriptor/csfs_cov/mod.rs
+++ b/src/descriptor/csfs_cov/mod.rs
@@ -84,7 +84,7 @@ mod tests {
 
     fn string_rtt(desc_str: &str) {
         let desc = Descriptor::<String>::from_str(desc_str).unwrap();
-        assert_eq!(desc.to_string_no_chksum(), desc_str);
+        assert_eq!(format!("{:#}", desc), desc_str);
         let cov_desc = desc.as_cov().unwrap();
         assert_eq!(cov_desc.to_string(), desc.to_string());
     }

--- a/src/descriptor/mod.rs
+++ b/src/descriptor/mod.rs
@@ -434,10 +434,6 @@ impl<Pk: MiniscriptKey, Ext: Extension> Descriptor<Pk, Ext> {
         }
     }
 
-    /// Return a string without the checksum
-    pub fn to_string_no_chksum(&self) -> String {
-        format!("{:?}", self)
-    }
     /// Checks whether the descriptor is safe.
     ///
     /// Checks whether all the spend paths in the descriptor are possible on the


### PR DESCRIPTION
This method has been made redundant by the `{:#}` display specifier since 7577e8ceda6d7c83be4f4422ec9be39c11f9050c two years ago. It is poorly named, inefficient since it always requires allocating a `String`, and also broken because it uses debug display for keys.

All of our unit tests were converted over to use :# which is why it wasn't noticed that this method didn't work.

Fixes #34
Fixes #85