### PR TITLE
avoid setting {BITCOIND,ELEMENTSD}_EXE in setup

### DIFF
--- a/bitcoind-tests/tests/setup/mod.rs
+++ b/bitcoind-tests/tests/setup/mod.rs
@@ -17,14 +17,6 @@ pub mod test_util;
 // We are not using pegins right now, but it might be required in case in future
 // if we extend the tests to check pegins etc.
 pub fn setup(validate_pegin: bool) -> (ElementsD, Option<BitcoinD>, elements::BlockHash) {
-    // Lookup bitcoind binary path
-    let curr_dir = std::env::current_dir().unwrap();
-    let bitcoind_path = curr_dir.join("bin/bitcoind");
-    let elementsd_path = curr_dir.join("bin/elementsd");
-
-    std::env::set_var("BITCOIND_EXE", bitcoind_path);
-    std::env::set_var("ELEMENTSD_EXE", elementsd_path);
-
     let mut bitcoind = None;
     if validate_pegin {
         let bitcoind_exe = bitcoind::exe_path().unwrap();

--- a/contrib/test.sh
+++ b/contrib/test.sh
@@ -22,7 +22,14 @@ fi
 
 # Test bitcoind integration tests if told to (this only works with the stable toolchain)
 if [ "$DO_BITCOIND_TESTS" = true ]; then
+
+    BITCOIND_EXE_DEFAULT="$(git rev-parse --show-toplevel)/bitcoind-tests/bin/bitcoind"
+    ELEMENTSD_EXE_DEFAULT="$(git rev-parse --show-toplevel)/bitcoind-tests/bin/elementsd"
+
     cd bitcoind-tests
+
+    BITCOIND_EXE=${BITCOIND_EXE:=${BITCOIND_EXE_DEFAULT}} \
+    ELEMENTSD_EXE=${ELEMENTSD_EXE:=${ELEMENTSD_EXE_DEFAULT}} \
     cargo test --verbose
 
     # Exit integration tests, do not run other tests.


### PR DESCRIPTION
The logic of setting the env var inside the setup prevents user of other OS like nixos to run the tests (because the included binary are not working on nixos) and also to run other specific versions.
Setting those env vars is meant to be done in the dev environment not in the code, so this remove the setting of the env vars in the code.
With this users with `bitcoind` and `elementsd` in their PATH will work too.
The CI script will set the variables with the included binary only if they are not already set. This allows the CI to run while allowing other users to override with specific versions and run it locally.

Note this is different from what has been done upstream https://github.com/rust-bitcoin/rust-miniscript/pull/538/ but I think it's better