### PR TITLE
Check input charset

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -51,7 +51,7 @@ roundtrip_confidential,
           echo "Using RUSTFLAGS $RUSTFLAGS"
           cd fuzz && ./fuzz.sh "${{ matrix.fuzz_target }}"
       - run: echo "${{ matrix.fuzz_target }}" >executed_${{ matrix.fuzz_target }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: executed_${{ matrix.fuzz_target }}
           path: executed_${{ matrix.fuzz_target }}
@@ -62,7 +62,7 @@ roundtrip_confidential,
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
       - name: Display structure of downloaded files
         run: ls -R
       - run: find executed_* -type f -exec cat {} + | sort > executed

--- a/fuzz/generate-files.sh
+++ b/fuzz/generate-files.sh
@@ -82,7 +82,7 @@ $(for name in $(listTargetNames); do echo "$name,"; done)
           echo "Using RUSTFLAGS \$RUSTFLAGS"
           cd fuzz && ./fuzz.sh "\${{ matrix.fuzz_target }}"
       - run: echo "\${{ matrix.fuzz_target }}" >executed_\${{ matrix.fuzz_target }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: executed_\${{ matrix.fuzz_target }}
           path: executed_\${{ matrix.fuzz_target }}

--- a/src/descriptor/checksum.rs
+++ b/src/descriptor/checksum.rs
@@ -8,6 +8,8 @@
 use core::fmt;
 use core::iter::FromIterator;
 
+use bitcoin_miniscript::expression::check_valid_chars;
+
 use crate::Error;
 
 const INPUT_CHARSET: &str =  "0123456789()[],'/*abcdefgh@:$%{}IJKLMNOPQRSTUVWXYZ&+-.;<=>?!^_|~ijklmnopqrstuvwxyzABCDEFGH`#\"\\ ";
@@ -51,11 +53,7 @@ pub fn desc_checksum(desc: &str) -> Result<String, Error> {
 /// if it is present and returns the descriptor string
 /// without the checksum
 pub(crate) fn verify_checksum(s: &str) -> Result<&str, Error> {
-    for ch in s.as_bytes() {
-        if *ch < 20 || *ch > 127 {
-            return Err(Error::Unprintable(*ch));
-        }
-    }
+    check_valid_chars(s)?;
 
     let mut parts = s.splitn(2, '#');
     let desc_str = parts.next().unwrap();

--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::{fmt, hash};
 
+use bitcoin_miniscript::expression::check_valid_chars;
 use elements::taproot::{
     LeafVersion, TaprootBuilder, TaprootSpendInfo, TAPROOT_CONTROL_BASE_SIZE,
     TAPROOT_CONTROL_MAX_NODE_COUNT, TAPROOT_CONTROL_NODE_SIZE,
@@ -716,11 +717,7 @@ impl<Pk: MiniscriptKey, Ext: Extension> fmt::Display for Tr<Pk, Ext> {
 
 // Helper function to parse string into miniscript tree form
 fn parse_tr_tree(s: &str) -> Result<expression::Tree<'_>, Error> {
-    for ch in s.bytes() {
-        if !ch.is_ascii() {
-            return Err(Error::Unprintable(ch));
-        }
-    }
+    check_valid_chars(s)?;
 
     if s.len() > 5 && &s[..5] == "eltr(" && s.as_bytes()[s.len() - 1] == b')' {
         let rest = &s[5..s.len() - 1];

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -7,6 +7,8 @@
 use std::fmt;
 use std::str::FromStr;
 
+use bitcoin_miniscript::expression::check_valid_chars;
+
 use crate::{errstr, Error, MAX_RECURSION_DEPTH};
 
 #[derive(Debug, Clone)]
@@ -202,13 +204,7 @@ impl<'a> Tree<'a> {
     /// Parses a tree from a string
     #[allow(clippy::should_implement_trait)] // seems to be a false positive
     pub fn from_str(s: &'a str) -> Result<Tree<'a>, Error> {
-        // Filter out non-ASCII because we byte-index strings all over the
-        // place and Rust gets very upsbt when you splinch a string.
-        for ch in s.bytes() {
-            if !ch.is_ascii() {
-                return Err(Error::Unprintable(ch));
-            }
-        }
+        check_valid_chars(s)?;
 
         let (top, rem) = Tree::from_slice(s)?;
         if rem.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -296,8 +296,6 @@ pub enum Error {
     CmsTooManyKeys(u32),
     /// A tapscript multi_a cannot support more than MAX_BLOCK_WEIGHT/32 keys
     MultiATooManyKeys(u32),
-    /// Encountered unprintable character in descriptor
-    Unprintable(u8),
     /// expected character while parsing descriptor; didn't find one
     ExpectedChar(char),
     /// While parsing backward, hit beginning of script
@@ -463,7 +461,6 @@ impl fmt::Display for Error {
             Error::Script(ref e) => fmt::Display::fmt(e, f),
             Error::AddrError(ref e) => fmt::Display::fmt(e, f),
             Error::CmsTooManyKeys(n) => write!(f, "checkmultisig with {} keys", n),
-            Error::Unprintable(x) => write!(f, "unprintable character 0x{:02x}", x),
             Error::ExpectedChar(c) => write!(f, "expected {}", c),
             Error::UnexpectedStart => f.write_str("unexpected start of script"),
             Error::Unexpected(ref s) => write!(f, "unexpected «{}»", s),
@@ -537,7 +534,6 @@ impl error::Error for Error {
             | InvalidPush(_)
             | CmsTooManyKeys(_)
             | MultiATooManyKeys(_)
-            | Unprintable(_)
             | ExpectedChar(_)
             | UnexpectedStart
             | Unexpected(_)

--- a/src/policy/concrete.rs
+++ b/src/policy/concrete.rs
@@ -7,6 +7,7 @@
 use std::collections::HashSet;
 use std::{error, fmt, str};
 
+use bitcoin_miniscript::expression::check_valid_chars;
 use elements::{LockTime, Sequence};
 #[cfg(feature = "compiler")]
 use {
@@ -1098,11 +1099,7 @@ impl_from_str!(
     Policy<Pk>,
     type Err = Error;,
     fn from_str(s: &str) -> Result<Policy<Pk>, Error> {
-        for ch in s.as_bytes() {
-            if *ch < 20 || *ch > 127 {
-                return Err(Error::Unprintable(*ch));
-            }
-        }
+        check_valid_chars(s)?;
 
         let tree = expression::Tree::from_str(s)?;
         let policy: Policy<Pk> = FromTree::from_tree(&tree)?;

--- a/src/policy/semantic.rs
+++ b/src/policy/semantic.rs
@@ -6,6 +6,7 @@
 use std::str::FromStr;
 use std::{fmt, str};
 
+use bitcoin_miniscript::expression::check_valid_chars;
 use elements::{LockTime, Sequence};
 
 use super::concrete::PolicyError;
@@ -287,11 +288,7 @@ impl_from_str!(
     Policy<Pk>,
     type Err = Error;,
     fn from_str(s: &str) -> Result<Policy<Pk>, Error> {
-        for ch in s.as_bytes() {
-            if *ch < 20 || *ch > 127 {
-                return Err(Error::Unprintable(*ch));
-            }
-        }
+        check_valid_chars(s)?;
 
         let tree = expression::Tree::from_str(s)?;
         expression::FromTree::from_tree(&tree)


### PR DESCRIPTION
Fix errors with unprintable ascii chars like `656c74722874706b7561667465726c6f6132196f72616561667465726c6f72616561667465726c6f725f69693229` for roundtrip_descriptor

Note in 0196695722074ca3c51472bfc81625dce719cd80 I replaced the custom impl with usptream fn for coherence, but the removed impl seems better than upstream (just checking the byte range seems equivalent)