### PR TITLE
simplicity: swap program and witness data in satisfaction

### DIFF
--- a/src/descriptor/tr.rs
+++ b/src/descriptor/tr.rs
@@ -554,7 +554,7 @@ impl<'a, Pk: ToPublicKey, Ext: ParseableExt> TapLeafScript<'a, Pk, Ext> {
                 let satisfier = crate::simplicity::SatisfierWrapper::new(satisfier);
                 let program = sim.satisfy(&satisfier).map_err(|_| Error::CouldNotSatisfy)?;
                 let (program_bytes, witness_bytes) = program.encode_to_vec();
-                Ok(vec![program_bytes, witness_bytes])
+                Ok(vec![witness_bytes, program_bytes])
             }
         }
     }


### PR DESCRIPTION
These are backward, which I noticed when constructing a Simplicity transaction for Liquid Testnet. There isn't an easy way to unit test this but I confirmed that the new order is the correct one on the live network.
