### PR TITLE
Add `translate_pk` method for `ConfidentialDescriptor`

### DIFF
--- a/examples/confidential_translate_pk.rs
+++ b/examples/confidential_translate_pk.rs
@@ -1,0 +1,50 @@
+// Example: using translate_pk on a confidential descriptor to go from wildcard
+// DescriptorPublicKey keys to concrete DefiniteDescriptorKey keys at a given
+// derivation index, then derive a confidential address.
+
+extern crate elements_miniscript as miniscript;
+
+use std::str::FromStr;
+
+use miniscript::{
+    confidential, translate_hash_clone, DefiniteDescriptorKey, DescriptorPublicKey, NoExt,
+    Translator,
+};
+
+struct IndexTranslator(u32);
+
+impl Translator<DescriptorPublicKey, DefiniteDescriptorKey, ()> for IndexTranslator {
+    fn pk(&mut self, pk: &DescriptorPublicKey) -> Result<DefiniteDescriptorKey, ()> {
+        pk.clone().at_derivation_index(self.0).map_err(|_| ())
+    }
+
+    translate_hash_clone!(DescriptorPublicKey, DefiniteDescriptorKey, ());
+}
+
+fn main() {
+    let secp = elements::secp256k1_zkp::Secp256k1::new();
+
+    // Confidential descriptor: SLIP77 blinding key + wildcard P2WPKH spend key.
+    let desc_str = "ct(\
+        slip77(b2396b3ee20509cdb64fe24180a14a72dbd671728eaa49bac69d2bdecb5f5a04),\
+        elwpkh(xpub661MyMwAqRbcEcT9W98HZP2kFzyzQQZkYnrRnrM8uD8kH8kSeFoQHq1x2iihLg\
+        C6PXGy5LrjCL66uSNhJ8pwjfx2rMUTLWuRMns2EG9xnjs/*))";
+
+    let desc = confidential::Descriptor::<DescriptorPublicKey, NoExt>::from_str(desc_str).unwrap();
+
+    for index in 0..3 {
+        let definite: confidential::Descriptor<DefiniteDescriptorKey, NoExt> =
+            desc.translate_pk(&mut IndexTranslator(index)).unwrap();
+
+        let conf_addr = definite
+            .address(&secp, &elements::AddressParams::LIQUID)
+            .unwrap();
+        let unconf_addr = definite
+            .unconfidential_address(&elements::AddressParams::LIQUID)
+            .unwrap();
+
+        println!("index {index}:");
+        println!("  confidential:   {conf_addr}");
+        println!("  unconfidential: {unconf_addr}");
+    }
+}

--- a/src/confidential/mod.rs
+++ b/src/confidential/mod.rs
@@ -33,7 +33,7 @@ use crate::descriptor::{
 };
 use crate::expression::FromTree;
 use crate::extensions::{CovExtArgs, CovenantExt, Extension, ParseableExt};
-use crate::{expression, Error, MiniscriptKey, ToPublicKey};
+use crate::{expression, Error, MiniscriptKey, ToPublicKey, TranslatePk, Translator};
 
 /// A description of a blinding key
 #[derive(Clone, PartialEq, Eq, Debug)]
@@ -162,6 +162,23 @@ impl<T: Extension + ParseableExt> Descriptor<DescriptorPublicKey, T> {
         Ok(Descriptor{
             key: definite_key,
             descriptor: definite_descriptor,
+        })
+    }
+}
+
+impl<Pk: MiniscriptKey, Ext: Extension> Descriptor<Pk, Ext> {
+    /// Converts a descriptor using one kind of keys to another kind of key.
+    ///
+    /// The blinding [`Key`] is preserved as-is; only the inner script descriptor's
+    /// keys are translated via the supplied [`Translator`].
+    pub fn translate_pk<Q, E, Tr>(&self, t: &mut Tr) -> Result<Descriptor<Q, Ext>, E>
+    where
+        Q: MiniscriptKey,
+        Tr: Translator<Pk, Q, E>,
+    {
+        Ok(Descriptor {
+            key: self.key.clone(),
+            descriptor: self.descriptor.translate_pk(t)?,
         })
     }
 }
@@ -329,7 +346,6 @@ mod tests {
             "xpub69H7F5d8KSRgmmdJg2KhpAK8SR3DjMwAdkxj3ZuxV27CprR9LgpeyGmXUbC6wb7ERfvrnKZjXoUmmDznezpbZb7ap6r1D3tgFxHmwMkQTPH",
         )
         .unwrap();
-
 
         let single_ct_key = DescriptorPublicKey::from_str(
             "02dce16018bbbb8e36de7b394df5b5166e9adb7498be7d881a85a09aeecf76b623",


### PR DESCRIPTION
The reasoning behind this PR is a small enhancement in developer experience. `miniscript::Descriptor` has [`translate_pk`](https://docs.rs/miniscript/latest/miniscript/descriptor/enum.Descriptor.html#method.translate_pk) method, but [`ConfidentialDescriptor`](https://docs.rs/elements-miniscript/latest/elements_miniscript/confidential/struct.Descriptor.html) does not. Because of this, to translate the inner descriptor, the user needs to extract it and then move the key:

```rust
let conf_descriptor = ConfidentialDescriptor::<DescriptorPublicKey>::from_str(&descriptor_str).unwrap();

let definite_desc = conf_descriptor
    .descriptor
    .translate_pk(&mut translator)
    .unwrap();

let definite_conf_descriptor = ConfidentialDescriptor {
    descriptor: definite_desc,
    key: conf_descriptor.key,
};

definite_conf_descriptor.address(SECP256K1, &AddressParams::LIQUID)
```

When in `miniscript`, this can be done with method chain calls:

```rust
let descriptor = Descriptor::<DescriptorPublicKey>::from_str(&wallet.descriptor).unwrap();

descriptor
    .translate_pk(&mut translator)
    .unwrap()
    .address(Network::Bitcoin)
```