### PR TITLE
fix: error instead of panic for hardened blinding keys

### DIFF
--- a/src/confidential/mod.rs
+++ b/src/confidential/mod.rs
@@ -84,6 +84,9 @@ impl Key {
                     // since there is not wildcard.
                     // Consider adding DescriptorPublicKey::to_definite_descriptor
                     let pk = pk.clone().at_derivation_index(0).expect("single or xpub without wildcards");
+                    // Derive explicitly rather than relying on ToPublicKey::to_public_key,
+                    // which panics on keys with hardened derivation steps.
+                    let pk = pk.derive_public_key(secp)?;
                     Ok(bare::tweak_key(secp, spk, &pk))
                 }
             },
@@ -563,6 +566,49 @@ mod tests {
         let desc_str = format!("ct({view_key},elwpkh({pk}))#n9uc7tzt");
         let desc = Descriptor::<DefiniteDescriptorKey>::from_str(&desc_str).unwrap();
         assert!(matches!(desc.key, Key::View(_)));
+    }
+
+    // A blinding key with a hardened derivation step cannot be derived from an xpub. This
+    // must be reported as an error rather than panicking in `ToPublicKey::to_public_key`,
+    // which unwraps the `ConversionError` returned by `derive_public_key`.
+    #[test]
+    fn descriptor_hardened_blinding_key() {
+        let secp = secp256k1_zkp::Secp256k1::new();
+        let params = &elements::AddressParams::LIQUID;
+
+        let xpub = "xpub661MyMwAqRbcEcT9W98HZP2kFzyzQQZkYnrRnrM8uD8kH8kSeFoQHq1x2iihLgC6PXGy5LrjCL66uSNhJ8pwjfx2rMUTLWuRMns2EG9xnjs";
+
+        let desc: Descriptor<DefiniteDescriptorKey, NoExt> = Descriptor {
+            key: Key::Bare(DescriptorPublicKey::from_str(&format!("{}/0h", xpub)).unwrap()),
+            descriptor: crate::Descriptor::new_wpkh(
+                DefiniteDescriptorKey::from_str(xpub).unwrap(),
+            )
+            .unwrap(),
+        };
+
+        assert_eq!(
+            desc.address(&secp, params).unwrap_err(),
+            Error::Conversion(ConversionError::HardenedChild)
+        );
+    }
+
+    // Same case, reached through `at_derivation_index` on a hardened wildcard blinding
+    // key: the wildcard is replaced by a hardened child, which the xpub cannot derive.
+    #[test]
+    fn descriptor_hardened_wildcard_blinding_key() {
+        let secp = secp256k1_zkp::Secp256k1::new();
+        let params = &elements::AddressParams::LIQUID;
+
+        let xpub = "xpub661MyMwAqRbcEcT9W98HZP2kFzyzQQZkYnrRnrM8uD8kH8kSeFoQHq1x2iihLgC6PXGy5LrjCL66uSNhJ8pwjfx2rMUTLWuRMns2EG9xnjs";
+        let desc_str = format!("ct({}/*h,elwpkh({}/*))", xpub, xpub);
+
+        let desc = Descriptor::<DescriptorPublicKey, NoExt>::from_str(&desc_str).unwrap();
+        let definite_desc = desc.at_derivation_index(1).unwrap();
+
+        assert_eq!(
+            definite_desc.address(&secp, params).unwrap_err(),
+            Error::Conversion(ConversionError::HardenedChild)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Return an error instead of panic when a blinding key uses hardened derivation

The code that turned the descriptor's blinding key into an actual public
key assumed the step could never fail, so asking such a descriptor for
its address crashed instead of returning an error. 

The new tests cover both ways of running into this: writing a hardened
step directly into the blinding key, and using a hardened wildcard that
gets filled in with a specific index later.

Closes #102